### PR TITLE
Fixes minor bug in Get Mail Message operation.

### DIFF
--- a/cs-mail/src/main/java/io/cloudslang/content/mail/services/GetMailMessage.java
+++ b/cs-mail/src/main/java/io/cloudslang/content/mail/services/GetMailMessage.java
@@ -139,6 +139,7 @@ public class GetMailMessage {
                 if (subject == null) {
                     subject = "";
                 }
+                result.put(SUBJECT, MimeUtility.decodeText(subject));
                 result.put(RETURN_RESULT, MimeUtility.decodeText(subject));
             } else {
                 try {

--- a/cs-mail/src/test/java/io/cloudslang/content/mail/services/GetMailMessageTest.java
+++ b/cs-mail/src/test/java/io/cloudslang/content/mail/services/GetMailMessageTest.java
@@ -207,6 +207,7 @@ public class GetMailMessageTest {
 
         Map<String, String> result = getMailMessageSpy.execute(inputs);
         assertEquals(subjectTest, result.get(RETURN_RESULT));
+        assertEquals(subjectTest, result.get(SUBJECT_RESULT));
         verify(getMailMessageSpy).getMessage();
         verify(messageMock).setFlag(Flags.Flag.DELETED, true);
         verify(messageMock).getSubject();
@@ -233,6 +234,7 @@ public class GetMailMessageTest {
 
         Map<String, String> result = getMailMessageSpy.execute(inputs);
         assertEquals(SUBJECT_TEST, result.get(RETURN_RESULT));
+        assertEquals(SUBJECT_TEST, result.get(SUBJECT_RESULT));
         verify(getMailMessageSpy).getMessage();
         verify(messageMock).getHeader("Subject");
         verify(getMailMessageSpy).changeHeaderCharset(anyString(), anyString());


### PR DESCRIPTION
When the input subjectOnly is true the Subject output field is not properly populated. 

Signed-off-by: Razvan Lupu razvan.lupu@hpe.com