### PR TITLE
Revert gson version to 2.6.2 because of jclouds issue.

### DIFF
--- a/cs-amazon/pom.xml
+++ b/cs-amazon/pom.xml
@@ -225,7 +225,7 @@
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>
-            <version>2.7</version>
+            <version>2.6.2</version>
         </dependency>
         <dependency>
             <groupId>commons-validator</groupId>


### PR DESCRIPTION
Signed-off-by: George Giloan, giloan@hpe.com