### PR TITLE
Fix HTTPClientGet

### DIFF
--- a/cs-http-client/src/main/java/io/cloudslang/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
+++ b/cs-http-client/src/main/java/io/cloudslang/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
@@ -98,9 +98,12 @@ public class SSLConnectionSocketFactoryBuilder {
         } else {
             try {
                 //need to override isTrusted() method to accept CA certs because the Apache HTTP Client ver.4.3 will only accepts self-signed certificates
-                KeyStore keyStore = createKeyStore(new URL("file:" + javaKeystore), changeit);
+                KeyStore keyStore = createKeyStore(new URL("file:" + keystore), keystorePassword);
+                sslContextBuilder.loadKeyMaterial(keyStore, keystorePassword.toCharArray());
 
-                sslContextBuilder.loadTrustMaterial(keyStore, new TrustSelfSignedStrategy() {
+                String internalJavaKeystoreUri = "file:" + System.getProperty("java.home") + "/lib/security/cacerts";
+                KeyStore javaTrustStore = createKeyStore(new URL(internalJavaKeystoreUri), changeit);
+                sslContextBuilder.loadTrustMaterial(javaTrustStore, new TrustSelfSignedStrategy() {
                     @Override
                     public boolean isTrusted(X509Certificate[] chain, String authType)
                             throws CertificateException {

--- a/cs-http-client/src/main/java/io/cloudslang/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
+++ b/cs-http-client/src/main/java/io/cloudslang/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilder.java
@@ -101,7 +101,7 @@ public class SSLConnectionSocketFactoryBuilder {
                 KeyStore keyStore = createKeyStore(new URL("file:" + keystore), keystorePassword);
                 sslContextBuilder.loadKeyMaterial(keyStore, keystorePassword.toCharArray());
 
-                String internalJavaKeystoreUri = "file:" + System.getProperty("java.home") + "/lib/security/cacerts";
+                String internalJavaKeystoreUri = "file:" + javaKeystore;
                 KeyStore javaTrustStore = createKeyStore(new URL(internalJavaKeystoreUri), changeit);
                 sslContextBuilder.loadTrustMaterial(javaTrustStore, new TrustSelfSignedStrategy() {
                     @Override

--- a/cs-http-client/src/test/java/io/cloudslang/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilderTest.java
+++ b/cs-http-client/src/test/java/io/cloudslang/content/httpclient/build/conn/SSLConnectionSocketFactoryBuilderTest.java
@@ -102,6 +102,8 @@ public class SSLConnectionSocketFactoryBuilderTest {
     public void buildWithTrustAllRoots() throws Exception {
         builder = new SSLConnectionSocketFactoryBuilder();
         builder.setTrustAllRoots("true");
+        builder.setKeystore(System.getProperty("java.home") + "/lib/security/cacerts");
+        builder.setKeystorePassword("changeit");
         mockStatic(SSLContexts.class);
 
         when(SSLContexts.custom()).thenReturn(sslContextBuilderMock);


### PR DESCRIPTION
 Fix error "bad_certificate" when input trustAllRoots is set on true, when ran against a CAC enabled server
 Signed off by Liviu Graur: liviu.graur@hpe.com