### PR TITLE
VMware fixes

### DIFF
--- a/cs-vmware/src/main/java/io/cloudslang/content/vmware/actions/cluster/GetVmOverrides.java
+++ b/cs-vmware/src/main/java/io/cloudslang/content/vmware/actions/cluster/GetVmOverrides.java
@@ -88,7 +88,7 @@ public class GetVmOverrides {
                                               @Param(value = PORT) String port,
                                               @Param(value = PROTOCOL) String protocol,
                                               @Param(value = USERNAME, required = true) String username,
-                                              @Param(value = PASSWORD, encrypted = true) String password,
+                                              @Param(value = PASSWORD, encrypted = true, required = true) String password,
                                               @Param(value = TRUST_EVERYONE) String trustEveryone,
                                               @Param(value = HOSTNAME, required = true) String hostname,
                                               @Param(value = VM_NAME) String virtualMachineName,

--- a/cs-vmware/src/main/java/io/cloudslang/content/vmware/services/ClusterComputeResourceService.java
+++ b/cs-vmware/src/main/java/io/cloudslang/content/vmware/services/ClusterComputeResourceService.java
@@ -95,24 +95,29 @@ public class ClusterComputeResourceService {
     }
 
     public String getVmOverride(final HttpInputs httpInputs, final VmInputs vmInputs) throws Exception {
-        final ConnectionResources connectionResources = new ConnectionResources(httpInputs, vmInputs);
+        ConnectionResources connectionResources = null;
+        try {
+            connectionResources = new ConnectionResources(httpInputs, vmInputs);
 
-        final ManagedObjectReference clusterMor = new MorObjectHandler().getSpecificMor(connectionResources, connectionResources.getMorRootFolder(),
-                ClusterParameter.CLUSTER_COMPUTE_RESOURCE.getValue(), vmInputs.getClusterName());
+            final ManagedObjectReference clusterMor = new MorObjectHandler().getSpecificMor(connectionResources, connectionResources.getMorRootFolder(),
+                    ClusterParameter.CLUSTER_COMPUTE_RESOURCE.getValue(), vmInputs.getClusterName());
 
-        final ClusterConfigInfoEx clusterConfigInfoEx = getClusterConfiguration(connectionResources, clusterMor, vmInputs.getClusterName());
+            final ClusterConfigInfoEx clusterConfigInfoEx = getClusterConfiguration(connectionResources, clusterMor, vmInputs.getClusterName());
 
-        final String restartPriority;
-        if(StringUtilities.isNotBlank(vmInputs.getVirtualMachineId()) || StringUtilities.isNotBlank(vmInputs.getVirtualMachineName())) {
-            final ManagedObjectReference vmMor = getVirtualMachineReference(vmInputs, connectionResources);
-            restartPriority = getVmRestartPriority(clusterConfigInfoEx, vmMor);
-        } else {
-            restartPriority = getVmRestartPriority(clusterConfigInfoEx);
+            final String restartPriority;
+            if (StringUtilities.isNotBlank(vmInputs.getVirtualMachineId()) || StringUtilities.isNotBlank(vmInputs.getVirtualMachineName())) {
+                final ManagedObjectReference vmMor = getVirtualMachineReference(vmInputs, connectionResources);
+                restartPriority = getVmRestartPriority(clusterConfigInfoEx, vmMor);
+            } else {
+                restartPriority = getVmRestartPriority(clusterConfigInfoEx);
+            }
+
+            return restartPriority;
+        } finally {
+            if(connectionResources != null && connectionResources.getConnection() != null) {
+                connectionResources.getConnection().disconnect();
+            }
         }
-
-        connectionResources.getConnection().disconnect();
-
-        return restartPriority;
     }
 
     private ManagedObjectReference getVirtualMachineReference(final VmInputs vmInputs, final ConnectionResources connectionResources) throws Exception {

--- a/cs-vmware/src/main/java/io/cloudslang/content/vmware/services/DeployOvfTemplateService.java
+++ b/cs-vmware/src/main/java/io/cloudslang/content/vmware/services/DeployOvfTemplateService.java
@@ -45,6 +45,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.jetbrains.annotations.NotNull;
 
+import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -201,7 +202,7 @@ public class DeployOvfTemplateService {
             final TarArchiveInputStream tar = new TarArchiveInputStream(new FileInputStream(templateFilePathStr));
             TarArchiveEntry entry;
             while ((entry = tar.getNextTarEntry()) != null) {
-                if (entry.getName().startsWith(vmdkName)) {
+                if (new File(entry.getName()).getName().startsWith(vmdkName)) {
                     return new TransferVmdkFromInputStream(tar, entry.getSize());
                 }
             }
@@ -232,7 +233,7 @@ public class DeployOvfTemplateService {
             try (final TarArchiveInputStream tar = new TarArchiveInputStream(new FileInputStream(templatePath))) {
                 TarArchiveEntry entry;
                 while ((entry = tar.getNextTarEntry()) != null) {
-                    if (isOvf(Paths.get(entry.getName()))) {
+                    if (isOvf(Paths.get(new File(entry.getName()).getName()))) {
                         return OvfUtils.writeToString(tar, entry.getSize());
                     }
                 }


### PR DESCRIPTION
Fixing get vm overrides: 
- closing session in case of failure
 - password required true

Fixing deploy ovf:
 - workaround: If the ovf was in posix format it had an prefix appended and the name was invalid

Signed-off-by: Tirla Florin-Alin <tirla@hpe.com>