### PR TITLE
Mark junit dependency with test scope

### DIFF
--- a/cs-mail/pom.xml
+++ b/cs-mail/pom.xml
@@ -293,6 +293,7 @@ http://www.apache.org/licenses/LICENSE-2.0
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>


### PR DESCRIPTION
Marked junit dependency with test scope so maven dependency plugin will no longer add it as a dependency.

Signed-off-by: Tirla Florin-Alin <tirla@hpe.com>