### PR TITLE
cs-xml updates

### DIFF
--- a/cs-xml/header-definitions.xml
+++ b/cs-xml/header-definitions.xml
@@ -1,12 +1,12 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <additionalHeaders>
     <cs-actions-java-header>
-        <firstLine>/*******************************************************************************</firstLine>
+        <firstLine>/***********************************************************************************************************************</firstLine>
         <beforeEachLine> </beforeEachLine>
-        <endLine> *******************************************************************************/</endLine>
+        <endLine>***********************************************************************************************************************/</endLine>
         <afterEachLine> </afterEachLine>
-        <firstLineDetectionPattern>/[*]{79}</firstLineDetectionPattern>
-        <lastLineDetectionPattern> [*]{79}/</lastLineDetectionPattern>
+        <firstLineDetectionPattern>/[*]{119}</firstLineDetectionPattern>
+        <lastLineDetectionPattern>[*]{119}/</lastLineDetectionPattern>
         <allowBlankLines>false</allowBlankLines>
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>

--- a/cs-xml/header-definitions.xml
+++ b/cs-xml/header-definitions.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <additionalHeaders>
     <cs-actions-java-header>
-        <firstLine>/***********************************************************************************************************************</firstLine>
+        <firstLine>/*</firstLine>
         <beforeEachLine> </beforeEachLine>
-        <endLine>***********************************************************************************************************************/</endLine>
+        <endLine>*/</endLine>
         <afterEachLine> </afterEachLine>
-        <firstLineDetectionPattern>/[*]{119}</firstLineDetectionPattern>
-        <lastLineDetectionPattern>[*]{119}/</lastLineDetectionPattern>
+        <firstLineDetectionPattern>/[*]</firstLineDetectionPattern>
+        <lastLineDetectionPattern> [*]/</lastLineDetectionPattern>
         <allowBlankLines>false</allowBlankLines>
         <isMultiline>true</isMultiline>
         <padLines>false</padLines>

--- a/cs-xml/pom.xml
+++ b/cs-xml/pom.xml
@@ -1,32 +1,32 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
-    <!--
-        (c) Copyright 2016 Hewlett-Packard Development Company, L.P.
-        All rights reserved. This program and the accompanying materials
-        are made available under the terms of the Apache License v2.0 which accompany this distribution.
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-        The Apache License is available at
-        http://www.apache.org/licenses/LICENSE-2.0
-    -->
+    <modelVersion>4.0.0</modelVersion>
+
     <groupId>io.cloudslang.content</groupId>
     <artifactId>cs-xml</artifactId>
     <version>0.0.11-SNAPSHOT</version>
     <packaging>jar</packaging>
+
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Actions for xml processing</description>
     <url>https://github.com/CloudSlang/cs-actions</url>
+
     <licenses>
         <license>
             <name>The Apache License, Version 2.0</name>
             <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
         </license>
     </licenses>
+
     <scm>
         <connection>scm:git:https://CloudSlang/cs-actions.git</connection>
         <developerConnection>scm:git:git@github.com:CloudSlang/cs-actions.git</developerConnection>
         <url>https://github.com/CloudSlang/cs-actions.git</url>
         <tag>master</tag>
     </scm>
+
     <developers>
         <developer>
             <name>Sam Markowitz</name>
@@ -35,6 +35,26 @@
             <organizationUrl>http://www8.hp.com/us/en/software/enterprise-software.html</organizationUrl>
         </developer>
     </developers>
+
+    <properties>
+        <!--Maven versions-->
+        <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
+        <maven-release-plugin.version>2.5.2</maven-release-plugin.version>
+        <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
+        <maven-delpoy-plugin.version>2.8.2</maven-delpoy-plugin.version>
+        <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>
+        <!--Dependencies versions-->
+        <score-content-sdk.version>1.10.6</score-content-sdk.version>
+        <cs-commons.version>0.0.4</cs-commons.version>
+        <cs-http-client.version>0.1.71</cs-http-client.version>
+        <junit.version>4.12</junit.version>
+        <!--Misc properties-->
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.source>1.7</maven.compiler.source>
+        <maven.compiler.target>1.7</maven.compiler.target>
+    </properties>
+
     <distributionManagement>
         <repository>
             <id>ossrh</id>
@@ -52,17 +72,17 @@
         <dependency>
             <groupId>com.hp.score.sdk</groupId>
             <artifactId>score-content-sdk</artifactId>
-            <version>1.5</version>
+            <version>${score-content-sdk.version}</version>
         </dependency>
         <dependency>
             <groupId>io.cloudslang.content</groupId>
             <artifactId>cs-http-client</artifactId>
-            <version>0.1.67</version>
+            <version>${cs-http-client.version}</version>
         </dependency>
         <dependency>
             <groupId>io.cloudslang.content</groupId>
             <artifactId>cs-commons</artifactId>
-            <version>0.0.4</version>
+            <version>${cs-commons.version}</version>
         </dependency>
         <dependency>
             <groupId>xerces</groupId>
@@ -119,30 +139,42 @@
                     </configuration>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-javadoc-plugin</artifactId>
-                    <version>2.8</version>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>${maven-compiler-plugin.version}</version>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
-                    <version>2.2.1</version>
+                    <version>${maven-source-plugin.version}</version>
                     <executions>
                         <execution>
                             <id>attach-sources</id>
-                            <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-release-plugin</artifactId>
+                    <version>${maven-release-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>${maven-delpoy-plugin.version}</version>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>${maven-javadoc-plugin.version}</version>
+                </plugin>
             </plugins>
         </pluginManagement>
+
         <plugins>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
-                <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
-                </configuration>
-            </plugin>
             <!--License checker for build-->
             <plugin>
                 <groupId>com.mycila</groupId>
@@ -177,67 +209,12 @@
             </plugin>
         </plugins>
     </build>
+
     <profiles>
-        <profile>
-            <id>default-profile</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.1</version>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
-            <id>release-internal-profile</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.2</version>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.1</version>
-                    </plugin>
-                    <plugin>
-                        <inherited>true</inherited>
-                        <artifactId>maven-source-plugin</artifactId>
-                        <version>2.2.1</version>
-                        <executions>
-                            <execution>
-                                <id>attach-sources-no-fork</id>
-                                <inherited>true</inherited>
-                                <goals>
-                                    <goal>jar-no-fork</goal>
-                                </goals>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
         <profile>
             <id>release-external-profile</id>
             <build>
                 <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-release-plugin</artifactId>
-                        <version>2.5.2</version>
-                    </plugin>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-deploy-plugin</artifactId>
-                        <version>2.8.1</version>
-                    </plugin>
                     <plugin>
                         <groupId>org.sonatype.plugins</groupId>
                         <artifactId>nexus-staging-maven-plugin</artifactId>
@@ -252,7 +229,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-gpg-plugin</artifactId>
-                        <version>1.5</version>
+                        <version>${maven-gpg-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>sign-artifacts</id>

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AddAttribute.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AddAttribute.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AddAttribute.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AddAttribute.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AppendChild.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AppendChild.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AppendChild.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/AppendChild.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ApplyXslTransformation.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ApplyXslTransformation.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ApplyXslTransformation.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ApplyXslTransformation.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertJsonToXml.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertJsonToXml.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertJsonToXml.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertJsonToXml.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertXmlToJson.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertXmlToJson.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertXmlToJson.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/ConvertXmlToJson.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/EditXml.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/EditXml.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/EditXml.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/EditXml.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/InsertBefore.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/InsertBefore.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/InsertBefore.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/InsertBefore.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Remove.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Remove.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Remove.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Remove.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/SetValue.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/SetValue.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/SetValue.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/SetValue.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Validate.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Validate.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Validate.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/Validate.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/XpathQuery.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/XpathQuery.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/actions/XpathQuery.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/actions/XpathQuery.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/ActionType.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/ActionType.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities;
 
 import io.cloudslang.content.xml.utils.Constants;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/ActionType.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/ActionType.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities;
 
 import io.cloudslang.content.xml.utils.Constants;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/SimpleNamespaceContext.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/SimpleNamespaceContext.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities;
 
 import javax.xml.namespace.NamespaceContext;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/SimpleNamespaceContext.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/SimpleNamespaceContext.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities;
 
 import javax.xml.namespace.NamespaceContext;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ApplyXslTransformationInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ApplyXslTransformationInputs.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.utils.StringUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ApplyXslTransformationInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ApplyXslTransformationInputs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.utils.StringUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CommonInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CommonInputs.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.InputUtils;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CommonInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CommonInputs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.InputUtils;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertJsonToXmlInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertJsonToXmlInputs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.Constants.Defaults;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertJsonToXmlInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertJsonToXmlInputs.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.Constants.Defaults;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertXmlToJsonInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertXmlToJsonInputs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.Constants.Defaults;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertXmlToJsonInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/ConvertXmlToJsonInputs.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.Constants.Defaults;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CustomInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CustomInputs.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.Constants;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CustomInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/CustomInputs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities.inputs;
 
 import io.cloudslang.content.xml.utils.Constants;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/EditXmlInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/EditXmlInputs.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.entities.inputs;
 
 import static io.cloudslang.content.xml.utils.ValidateUtils.validateIsNotEmpty;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/EditXmlInputs.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/entities/inputs/EditXmlInputs.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.entities.inputs;
 
 import static io.cloudslang.content.xml.utils.ValidateUtils.validateIsNotEmpty;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/factory/OperationFactory.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/factory/OperationFactory.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.factory;
 
 import io.cloudslang.content.xml.entities.ActionType;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/factory/OperationFactory.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/factory/OperationFactory.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.factory;
 
 import io.cloudslang.content.xml.entities.ActionType;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/AddAttributeService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/AddAttributeService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/AddAttributeService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/AddAttributeService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/AppendChildService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/AppendChildService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/AppendChildService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/AppendChildService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ApplyXslTransformationService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ApplyXslTransformationService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+ ***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.utils.OutputUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ApplyXslTransformationService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ApplyXslTransformationService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.utils.OutputUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ApplyXslTransformationService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ApplyXslTransformationService.java
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- ***********************************************************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.utils.OutputUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertJsonToXmlService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertJsonToXmlService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import com.google.gson.JsonArray;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertJsonToXmlService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertJsonToXmlService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import com.google.gson.JsonArray;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertXmlToJsonService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertXmlToJsonService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import com.google.gson.Gson;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertXmlToJsonService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ConvertXmlToJsonService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import com.google.gson.Gson;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/InsertBeforeService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/InsertBeforeService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/InsertBeforeService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/InsertBeforeService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/OperationService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/OperationService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/OperationService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/OperationService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/RemoveService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/RemoveService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/RemoveService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/RemoveService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/SetValueService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/SetValueService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/SetValueService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/SetValueService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.xml.entities.inputs.CommonInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ValidateService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ValidateService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/ValidateService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/ValidateService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/XpathQueryService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/XpathQueryService.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/XpathQueryService.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/XpathQueryService.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/AppendOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/AppendOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/AppendOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/AppendOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/DeleteOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/DeleteOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/DeleteOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/DeleteOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/InsertOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/InsertOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/InsertOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/InsertOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/MoveOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/MoveOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/MoveOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/MoveOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/RenameOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/RenameOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/RenameOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/RenameOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/SubnodeOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/SubnodeOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/SubnodeOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/SubnodeOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/UpdateOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/UpdateOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/UpdateOperationServiceImpl.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/services/impl/UpdateOperationServiceImpl.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.services.impl;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/Constants.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/Constants.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.constants.OutputNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/Constants.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/Constants.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.constants.OutputNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/DocumentUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/DocumentUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.utils;
 
 import org.apache.xml.serialize.OutputFormat;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/DocumentUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/DocumentUtils.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.utils;
 
 import org.apache.xml.serialize.OutputFormat;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/InputUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/InputUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.utils.BooleanUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/InputUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/InputUtils.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.utils.BooleanUtilities;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ResultUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ResultUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ResultUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ResultUtils.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ValidateUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ValidateUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ValidateUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/ValidateUtils.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.xml.entities.inputs.EditXmlInputs;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/XmlUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/XmlUtils.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.httpclient.CSHttpClient;

--- a/cs-xml/src/main/java/io/cloudslang/content/xml/utils/XmlUtils.java
+++ b/cs-xml/src/main/java/io/cloudslang/content/xml/utils/XmlUtils.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.utils;
 
 import io.cloudslang.content.httpclient.CSHttpClient;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AddAttributeTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AddAttributeTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AddAttributeTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AddAttributeTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AppendChildTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AppendChildTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AppendChildTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/AppendChildTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ApplyXslTransformationTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ApplyXslTransformationTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import org.apache.commons.io.FileUtils;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ApplyXslTransformationTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ApplyXslTransformationTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import org.apache.commons.io.FileUtils;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertJsonToXmlTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertJsonToXmlTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import org.junit.Before;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertJsonToXmlTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertJsonToXmlTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,10 +6,9 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
-import io.cloudslang.content.xml.utils.Constants.Outputs;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertXmlToJsonTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertXmlToJsonTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,12 +6,10 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
-import io.cloudslang.content.constants.BooleanValues;
 import io.cloudslang.content.constants.ReturnCodes;
-import io.cloudslang.content.utils.BooleanUtilities;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertXmlToJsonTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ConvertXmlToJsonTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ReturnCodes;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/EditXmlTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/EditXmlTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import org.apache.commons.io.IOUtils;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/EditXmlTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/EditXmlTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import org.apache.commons.io.IOUtils;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/InsertBeforeTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/InsertBeforeTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/InsertBeforeTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/InsertBeforeTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/RemoveTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/RemoveTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/RemoveTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/RemoveTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/SetValueTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/SetValueTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/SetValueTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/SetValueTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ValidateTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ValidateTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ValidateTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/ValidateTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/XpathQueryTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/XpathQueryTest.java
@@ -1,4 +1,4 @@
-/***********************************************************************************************************************
+/*
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
-***********************************************************************************************************************/
+*/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;

--- a/cs-xml/src/test/java/io/cloudslang/content/xml/actions/XpathQueryTest.java
+++ b/cs-xml/src/test/java/io/cloudslang/content/xml/actions/XpathQueryTest.java
@@ -1,4 +1,4 @@
-/*******************************************************************************
+/***********************************************************************************************************************
  * (c) Copyright 2017 Hewlett-Packard Development Company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
@@ -6,7 +6,7 @@
  * The Apache License is available at
  * http://www.apache.org/licenses/LICENSE-2.0
  *
- *******************************************************************************/
+***********************************************************************************************************************/
 package io.cloudslang.content.xml.actions;
 
 import io.cloudslang.content.constants.ResponseNames;


### PR DESCRIPTION
Updated pom (removed redundant plugins, added properties, no impact in build or release, tested on cs-utilities)
Updated score-content-sdk to 1.10.6
Updated cs-http-client 0.1.71
Updated header-definitions to 119 chars
Updated license headers

Signed-off-by: Sorin Moldovan <sorin@hpe.com>