### PR TITLE
Added missing description for the module

### DIFF
--- a/cs-dropbox/pom.xml
+++ b/cs-dropbox/pom.xml
@@ -24,6 +24,7 @@
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
+    <description>Java actions for DropBox integration</description>
     <url>https://github.com/CloudSlang/cs-actions</url>
 
     <licenses>


### PR DESCRIPTION
Maven Central validation fails if there is no desc.

Signed-off-by: moldovso <sorin@hpe.com>