### PR TITLE
PowerShell issue - '&&' replaced with ';'

### DIFF
--- a/cs-utilities/src/main/java/io/cloudslang/content/utilities/entities/constants/OsDetectorConstants.java
+++ b/cs-utilities/src/main/java/io/cloudslang/content/utilities/entities/constants/OsDetectorConstants.java
@@ -73,8 +73,8 @@ public class OsDetectorConstants {
     public static final String UNIX_OS_FAMILY_KEY = "FAMILY=";
     private static final String MAC_COMMAND = "sw_vers";
     private static final String WINDOWS_COMMAND = "systeminfo";
-    private static final String LINUX_COMMAND = "printf " + UNIX_OS_FAMILY_KEY + " && uname; printf " + LINUX_OS_ARCHITECTURE_KEY + " && uname -m; cat /etc/os-release;";
-    public static final String OS_DETECTOR_COMMAND = LINUX_COMMAND + " " + MAC_COMMAND + " || " + WINDOWS_COMMAND;
+    private static final String LINUX_COMMAND = "printf " + UNIX_OS_FAMILY_KEY + " ; uname; printf " + LINUX_OS_ARCHITECTURE_KEY + " ; uname -m; cat /etc/os-release;";
+    public static final String OS_DETECTOR_COMMAND = LINUX_COMMAND + " " + MAC_COMMAND + " ; " + WINDOWS_COMMAND;
     public static final String WINDOWS_LINE_SEPARATOR = "\r\n";
     public static final String UNIX_LINE_SEPARATOR = "\n";
     public static final String EARLY_MAC_LINE_SEPARATOR = "\r";


### PR DESCRIPTION
Issue when connecting to a remote windows server. PowerShell issue - '&&' replaced with ';'.

Signed-off-by: Lenuta Toderean lenuta.toderean@microfocus.com