### PR TITLE
Fix SQL Query operation infinite loop

### DIFF
--- a/cs-database/pom.xml
+++ b/cs-database/pom.xml
@@ -87,7 +87,7 @@
         <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <!--Dependencies versions-->
-        <score-content-sdk.version>1.10.6</score-content-sdk.version>
+        <score-content-sdk.version>1.10.7</score-content-sdk.version>
         <cs-commons.version>0.0.5</cs-commons.version>
         <junit.version>4.12</junit.version>
         <!--Misc properties-->

--- a/cs-database/src/main/java/io/cloudslang/content/database/utils/SQLInputsUtils.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/utils/SQLInputsUtils.java
@@ -60,13 +60,12 @@ public class SQLInputsUtils {
     }
 
     @NotNull
-    public static GlobalSessionObject<Map<String, Object>> getOrDefaultGlobalSessionObj(final GlobalSessionObject<Map<String, Object>> globalSessionObject) {
-        if (globalSessionObject != null && globalSessionObject.get() != null) {
+    public static GlobalSessionObject<Map<String, Object>> getOrDefaultGlobalSessionObj(@NotNull final GlobalSessionObject<Map<String, Object>> globalSessionObject) {
+        if (globalSessionObject.get() != null) {
             return globalSessionObject;
         }
-        final GlobalSessionObject<Map<String, Object>> newGlobalSessionObject = new GlobalSessionObject<>();
-        newGlobalSessionObject.setResource(new SQLSessionResource(new HashMap<String, Object>()));
-        return newGlobalSessionObject;
+        globalSessionObject.setResource(new SQLSessionResource(new HashMap<String, Object>()));
+        return globalSessionObject;
     }
 
     @NotNull

--- a/cs-database/src/test/java/io/cloudslang/content/database/actions/SQLQueryLOBTest.java
+++ b/cs-database/src/test/java/io/cloudslang/content/database/actions/SQLQueryLOBTest.java
@@ -19,34 +19,31 @@ import com.hp.oo.sdk.content.plugin.GlobalSessionObject;
 import io.cloudslang.content.database.constants.DBResponseNames;
 import io.cloudslang.content.database.constants.DBReturnCodes;
 import io.cloudslang.content.database.services.SQLQueryLobService;
-import io.cloudslang.content.database.services.SQLScriptService;
 import io.cloudslang.content.database.utils.SQLInputs;
 import io.cloudslang.content.database.utils.SQLInputsUtils;
 import io.cloudslang.content.database.utils.SQLSessionResource;
-import io.cloudslang.content.database.utils.SQLUtils;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Spy;
-import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static io.cloudslang.content.constants.BooleanValues.FALSE;
 import static io.cloudslang.content.constants.OutputNames.RETURN_CODE;
 import static io.cloudslang.content.constants.OutputNames.RETURN_RESULT;
 import static io.cloudslang.content.constants.ReturnCodes.FAILURE;
 import static io.cloudslang.content.constants.ReturnCodes.SUCCESS;
 import static io.cloudslang.content.database.constants.DBDefaultValues.AUTH_SQL;
-import static io.cloudslang.content.database.constants.DBOtherValues.CONCUR_READ_ONLY;
-import static io.cloudslang.content.database.constants.DBOtherValues.MSSQL_DB_TYPE;
-import static io.cloudslang.content.database.constants.DBOtherValues.TYPE_FORWARD_ONLY;
+import static io.cloudslang.content.database.constants.DBOtherValues.*;
 import static io.cloudslang.content.database.constants.DBReturnCodes.NO_MORE;
 import static org.apache.commons.lang3.StringUtils.EMPTY;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.powermock.api.mockito.PowerMockito.*;
 
@@ -112,7 +109,10 @@ public class SQLQueryLOBTest {
         assertThat(resultMap.get(RETURN_RESULT), is("a"));
     }
 
+    //GlobalSessionObject was implemented
+    //In CloudSlang the object is instantiated by default and cannot be null
     @Test
+    @Ignore
     public void executeSuccessNoGlobalSessionFailure() throws Exception {
         mockStatic(SQLQueryLobService.class);
 
@@ -124,4 +124,5 @@ public class SQLQueryLOBTest {
         verifyStatic();
         assertThat(resultMap.get(RETURN_CODE), is(DBReturnCodes.NO_MORE));
     }
+
 }

--- a/cs-database/src/test/java/io/cloudslang/content/database/utils/SQLInputsUtilsTest.java
+++ b/cs-database/src/test/java/io/cloudslang/content/database/utils/SQLInputsUtilsTest.java
@@ -18,6 +18,7 @@ package io.cloudslang.content.database.utils;
 import com.hp.oo.sdk.content.plugin.GlobalSessionObject;
 import io.cloudslang.content.database.services.databases.*;
 import org.jetbrains.annotations.NotNull;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
@@ -74,7 +75,10 @@ public class SQLInputsUtilsTest {
        assertThat(getOrDefaultDBClass("a", ORACLE_DB_TYPE), is("a"));
     }
 
+    //GlobalSessionObject was implemented
+    //In CloudSlang the object is instantiated by default and cannot be null
     @Test
+    @Ignore
     public void getOrDefaultGlobalSessionObjNull() throws Exception {
         final GlobalSessionObject<Map<String, Object>> globalSessionObj = getOrDefaultGlobalSessionObj(null);
         assertThat(globalSessionObj, instanceOf(GlobalSessionObject.class));


### PR DESCRIPTION
Fix SQL Query operation infinite loop
Ignore tests with null value for GlobalSessionObject
Update score-content-sdk version to 1.10.7 for cs-database module

Signed-off-by: graur <liviu.graur@hpe.com>