### PR TITLE
Extent base database content with Vertica coverage

### DIFF
--- a/cs-database/pom.xml
+++ b/cs-database/pom.xml
@@ -150,7 +150,7 @@
         <dependency>
            <groupId>com.microfocus.vertica</groupId>
            <artifactId>vertica-jdbc</artifactId>
-           <version>8.1.1-10</version>
+           <version>9.1.0-0</version>
         </dependency>
         <!-- Testing dependencies-->
         <dependency>

--- a/cs-database/pom.xml
+++ b/cs-database/pom.xml
@@ -147,6 +147,11 @@
             <artifactId>postgresql</artifactId>
             <version>9.4.1212.jre7</version>
         </dependency>
+        <dependency>
+           <groupId>com.microfocus.vertica</groupId>
+           <artifactId>vertica-jdbc</artifactId>
+           <version>8.1.1-10</version>
+        </dependency>
         <!-- Testing dependencies-->
         <dependency>
             <groupId>junit</groupId>

--- a/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLCommand.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLCommand.java
@@ -56,12 +56,12 @@ public class SQLCommand {
     /**
      * @param dbServerName              The hostname or ip address of the database server.
      * @param dbType                    The type of database to connect to.
-     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL and Custom.
+     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL, Vertica and Custom.
      * @param username                  The username to use when connecting to the database.
      * @param password                  The password to use when connecting to the database.
      * @param instance                  The name instance (for MSSQL Server). Leave it blank for default instance.
      * @param dbPort                    The port to connect to.
-     *                                  Default values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432.
+     *                                  Default values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432, Vertica:5433.
      * @param databaseName              The name of the database.
      * @param authenticationType        The type of authentication used to access the database (applicable only to MSSQL type).
      *                                  Default: sql

--- a/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLQuery.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLQuery.java
@@ -63,14 +63,14 @@ public class SQLQuery {
     /**
      * @param dbServerName              The hostname or ip address of the database server.
      * @param dbType                    The type of database to connect to
-     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL and Custom.
+     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL, Vertica and Custom.
      *                                  Default value: Oracle
      * @param username                  The username to use when connecting to the server.
      * @param password                  The password to use when connecting to the server.
      * @param instance                  The name instance of MSSQL Server. Leave it blank for default instance.
      *                                  Example: MSSQLSERVER
      * @param dbPort                    The port to connect to.
-     *                                  Valid values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432.
+     *                                  Default values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432, Vertica:5433.
      * @param databaseName              The name of the database to connect to.
      * @param authenticationType        The type of authentication used to access the database (applicable only to MSSQL type).
      *                                  Default: sql

--- a/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLQueryAllRows.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLQueryAllRows.java
@@ -55,14 +55,14 @@ public class SQLQueryAllRows {
     /**
      * @param dbServerName              The hostname or ip address of the database server.
      * @param dbType                    The type of database to connect to
-     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL and Custom.
+     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL, Vertica and Custom.
      *                                  Default value: Oracle
      * @param username                  The username to use when connecting to the server.
      * @param password                  The password to use when connecting to the server.
      * @param instance                  The name instance of MSSQL Server. Leave it blank for default instance.
      *                                  Example: MSSQLSERVER
      * @param dbPort                    The port to connect to.
-     *                                  Valid values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432.
+     *                                  Default values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432, Vertica:5433.
      * @param databaseName              The name of the database to connect to.
      * @param authenticationType        The type of authentication used to access the database (applicable only to MSSQL type).
      *                                  Default: sql
@@ -97,7 +97,7 @@ public class SQLQueryAllRows {
      *                                  Example: db.pooling.enable=true
      * @param resultSetType             the result set type. See JDBC folder description for more details.
      *                                  Valid values: TYPE_FORWARD_ONLY, TYPE_SCROLL_INSENSITIVE,TYPE_SCROLL_SENSITIVE.
-     *                                  Default value: TYPE_SCROLL_INSENSITIVE except DB2 which is overridden to TYPE_FORWARD_ONLY
+     *                                  Default value: TYPE_SCROLL_INSENSITIVE except for DB2 and Vertica which is overridden to TYPE_FORWARD_ONLY
      * @param resultSetConcurrency      the result set concurrency. See JDBC folder description for more details.
      *                                  Valid values: CONCUR_READ_ONLY, CONCUR_UPDATABLE
      *                                  Default value: CONCUR_READ_ONLY

--- a/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLQueryTabular.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/actions/SQLQueryTabular.java
@@ -56,12 +56,12 @@ public class SQLQueryTabular {
     /**
      * @param dbServerName              The hostname or ip address of the database server.
      * @param dbType                    The type of database to connect to.
-     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL and Custom.
+     *                                  Valid values: Oracle, MSSQL, Sybase, Netcool, DB2, PostgreSQL, Vertica and Custom.
      * @param username                  The username to use when connecting to the database.
      * @param password                  The password to use when connecting to the database.
      * @param instance                  The name instance (for MSSQL Server). Leave it blank for default instance.
      * @param dbPort                    The port to connect to.
-     *                                  Default values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432.
+     *                                  Default values: Oracle: 1521, MSSQL: 1433, Sybase: 5000, Netcool: 4100, DB2: 50000, PostgreSQL: 5432, Vertica:5433.
      * @param databaseName              The name of the database.
      * @param authenticationType        The type of authentication used to access the database (applicable only to MSSQL type).
      *                                  Default: sql

--- a/cs-database/src/main/java/io/cloudslang/content/database/constants/DBOtherValues.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/constants/DBOtherValues.java
@@ -41,6 +41,7 @@ public class DBOtherValues {
     public static final String DB2_DB_TYPE = "DB2";
     public static final String MYSQL_DB_TYPE = "MySQL";
     public static final String POSTGRES_DB_TYPE = "PostgreSQL";
+    public static final String VERTICA_DB_TYPE = "Vertica";
     public static final String CUSTOM_DB_TYPE = "Custom";
 
     public static final Integer DEFAULT_PORT_ORACLE = 1521;
@@ -50,6 +51,7 @@ public class DBOtherValues {
     public static final Integer DEFAULT_PORT_DB2 = 50000;
     public static final Integer DEFAULT_PORT_MYSQL = 3306;
     public static final Integer DEFAULT_PORT_PSQL = 5432;
+    public static final Integer DEFAULT_PORT_VERTICA = 5433;
     public static final Integer DEFAULT_PORT_CUSTOM = DEFAULT_PORT_ORACLE;
 
     public static final String ORACLE_JDBC_DRIVER = "oracle.jdbc.driver.OracleDriver";
@@ -59,6 +61,7 @@ public class DBOtherValues {
     public static final String DB2_DRIVER = "com.ibm.db2.jcc.DB2Driver";
     public static final String MYSQL_JDBC_DRIVER = "com.mysql.jdbc.Driver";
     public static final String POSTGRESQL_DRIVER = "org.postgresql.Driver";
+    public static final String VERTICA_DRIVER = "com.vertica.jdbc.Driver";
     public static final String MSSQL_FILE_DRIVER = "sqljdbc_auth.dll";
 
     public static final String KEY_COLUMNS = "%s - Columns";

--- a/cs-database/src/main/java/io/cloudslang/content/database/services/databases/VerticaDatabase.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/services/databases/VerticaDatabase.java
@@ -1,0 +1,58 @@
+/*
+ * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudslang.content.database.services.databases;
+
+import io.cloudslang.content.database.utils.Address;
+import io.cloudslang.content.database.utils.SQLInputs;
+import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.List;
+
+import static io.cloudslang.content.database.constants.DBOtherValues.FORWARD_SLASH;
+import static io.cloudslang.content.database.utils.SQLInputsUtils.getDbUrls;
+import static io.cloudslang.content.database.utils.SQLUtils.loadClassForName;
+
+/**
+ * Created by stefan on 11.05.2018.
+ */
+public class VerticaDatabase implements SqlDatabase {
+
+    @Override
+    public List<String> setUp(@NotNull final SQLInputs sqlInputs) {
+        loadClassForName("com.vertica.jdbc.Driver");
+        final String connectionString = getConnectionString(sqlInputs);
+        final List<String> dbUrls = getDbUrls(sqlInputs.getDbUrl());
+        dbUrls.add(connectionString);
+        return dbUrls;
+    }
+
+    private String getConnectionString(final SQLInputs sqlInputs) {
+        final Address address = new Address(sqlInputs.getDbServer());
+        final StringBuilder connectionSb = new StringBuilder("jdbc:vertica://");
+        if (address.isIPV6Literal()) {//the host is an IPv6 literal
+            connectionSb.append(String.format("[host=%s]:%d", sqlInputs.getDbServer(), sqlInputs.getDbPort()));
+        } else {
+            connectionSb.append(String.format("%s:%d", sqlInputs.getDbServer(), sqlInputs.getDbPort()));
+        }
+        if (StringUtils.isNoneEmpty(sqlInputs.getDbName())) {
+            connectionSb.append(FORWARD_SLASH)
+                    .append(sqlInputs.getDbName());
+        }
+        //the host is an IPv4 literal or a Host Name
+        return connectionSb.toString();
+    }
+}

--- a/cs-database/src/main/java/io/cloudslang/content/database/services/dbconnection/DBConnectionManager.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/services/dbconnection/DBConnectionManager.java
@@ -753,7 +753,7 @@ public class DBConnectionManager {
     }
 
     public enum DBType {
-        ORACLE, MSSQL, SYBASE, NETCOOL, DB2, MYSQL, POSTGRESQL, CUSTOM
+        ORACLE, MSSQL, SYBASE, NETCOOL, DB2, MYSQL, POSTGRESQL, VERTICA, CUSTOM
     }
 
 }//end DBConnectionManager

--- a/cs-database/src/main/java/io/cloudslang/content/database/utils/SQLInputsUtils.java
+++ b/cs-database/src/main/java/io/cloudslang/content/database/utils/SQLInputsUtils.java
@@ -136,6 +136,9 @@ public class SQLInputsUtils {
         if (DB2_DB_TYPE.equalsIgnoreCase(dbType)) {
             return TYPE_VALUES.get(TYPE_FORWARD_ONLY);
         }
+        if (VERTICA_DB_TYPE.equalsIgnoreCase(dbType)) {
+            return TYPE_VALUES.get(TYPE_FORWARD_ONLY);
+        }
         if (SQLInputsValidator.isValidResultSetType(resultSetType)) {
             return TYPE_VALUES.get(resultSetType);
         }
@@ -207,6 +210,7 @@ public class SQLInputsUtils {
         concurValues.put(DB2_DB_TYPE, DB2_DRIVER);
         concurValues.put(MYSQL_DB_TYPE, MYSQL_JDBC_DRIVER);
         concurValues.put(POSTGRES_DB_TYPE, POSTGRESQL_DRIVER);
+        concurValues.put(VERTICA_DB_TYPE, VERTICA_DRIVER);
         concurValues.put(CUSTOM_DB_TYPE, EMPTY);
         return concurValues;
     }
@@ -221,6 +225,7 @@ public class SQLInputsUtils {
         dbPortsValues.put(DB2_DB_TYPE, DEFAULT_PORT_DB2);
         dbPortsValues.put(MYSQL_DB_TYPE, DEFAULT_PORT_MYSQL);
         dbPortsValues.put(POSTGRES_DB_TYPE, DEFAULT_PORT_PSQL);
+        dbPortsValues.put(VERTICA_DB_TYPE, DEFAULT_PORT_VERTICA);
         dbPortsValues.put(CUSTOM_DB_TYPE, DEFAULT_PORT_CUSTOM);
         return dbPortsValues;
     }
@@ -251,6 +256,7 @@ public class SQLInputsUtils {
         dbForType.put(SYBASE_DB_TYPE, SybaseDatabase.class);
         dbForType.put(NETCOOL_DB_TYPE, NetcoolDatabase.class);
         dbForType.put(POSTGRES_DB_TYPE, PostgreSqlDatabase.class);
+        dbForType.put(VERTICA_DB_TYPE, VerticaDatabase.class);
         dbForType.put(DB2_DB_TYPE, DB2Database.class);
         dbForType.put(CUSTOM_DB_TYPE, CustomDatabase.class);
         return dbForType;
@@ -265,6 +271,7 @@ public class SQLInputsUtils {
         dbTypes.put(SYBASE_DB_TYPE, DBType.SYBASE);
         dbTypes.put(NETCOOL_DB_TYPE, DBType.NETCOOL);
         dbTypes.put(POSTGRES_DB_TYPE, DBType.POSTGRESQL);
+        dbTypes.put(VERTICA_DB_TYPE, DBType.VERTICA);
         dbTypes.put(DB2_DB_TYPE, DBType.DB2);
         dbTypes.put(CUSTOM_DB_TYPE, DBType.CUSTOM);
         return dbTypes;

--- a/cs-database/src/test/java/io/cloudslang/content/database/services/databases/VerticaDatabaseTest.java
+++ b/cs-database/src/test/java/io/cloudslang/content/database/services/databases/VerticaDatabaseTest.java
@@ -1,0 +1,95 @@
+/*
+ * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.cloudslang.content.database.services.databases;
+
+import io.cloudslang.content.database.utils.SQLInputs;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static junit.framework.Assert.assertEquals;
+import static org.apache.commons.lang3.StringUtils.EMPTY;
+
+public class VerticaDatabaseTest {
+
+    private static final String DB_NAME = "dbName";
+    private static final String DB_SERVER = "dbServer";
+    private static final int DB_PORT = 5433;
+    private static final String DB_SERVER_IPV6_LITERAL = "2001-0db8-85a3-0042-1000-8a2e-0370-7334.ipv6-literal.net";
+
+    @Rule
+    public ExpectedException expectedEx = ExpectedException.none();
+
+    @Test
+    public void testSetUpNoDbName() throws ClassNotFoundException, SQLException {
+        VerticaDatabase verticaDatabase = new VerticaDatabase();
+        final SQLInputs sqlInputs = SQLInputs.builder().build();
+        sqlInputs.setDbName(EMPTY);
+        sqlInputs.setDbServer(DB_SERVER);
+        sqlInputs.setDbPort(DB_PORT);
+//        sqlInputs.setDbUrls(new ArrayList<String>());
+
+        final List<String> dbUrls = verticaDatabase.setUp(sqlInputs);
+        assertEquals("jdbc:vertica://dbServer:5433", dbUrls.get(0));
+        assertEquals(1, dbUrls.size());
+    }
+
+    @Test
+    public void testSetUpNoServerName() throws ClassNotFoundException, SQLException {
+        expectedEx.expect(IllegalArgumentException.class);
+        expectedEx.expectMessage("host   not valid");
+        VerticaDatabase verticaDatabase = new VerticaDatabase();
+        final SQLInputs sqlInputs = SQLInputs.builder().build();
+        sqlInputs.setDbName(DB_NAME);
+        sqlInputs.setDbServer(null);
+        sqlInputs.setDbPort(DB_PORT);
+//        sqlInputs.setDbUrls(new ArrayList<String>());
+        verticaDatabase.setUp(sqlInputs);
+    }
+
+    @Test
+    public void testSetUpAll() throws ClassNotFoundException, SQLException {
+        VerticaDatabase verticaDatabase = new VerticaDatabase();
+        final SQLInputs sqlInputs = SQLInputs.builder().build();
+        sqlInputs.setDbName(DB_NAME);
+        sqlInputs.setDbServer(DB_SERVER);
+        sqlInputs.setDbPort(DB_PORT);
+//        sqlInputs.setDbUrls(new ArrayList<String>());
+        final List<String> dbUrls = verticaDatabase.setUp(sqlInputs);
+
+        assertEquals("jdbc:vertica://dbServer:5433/dbName", dbUrls.get(0));
+        assertEquals(1, dbUrls.size());
+    }
+
+    @Test
+    public void testSetUpAllIPV6LIteral() throws ClassNotFoundException, SQLException {
+        VerticaDatabase verticaDatabase = new VerticaDatabase();
+        final SQLInputs sqlInputs = SQLInputs.builder().build();
+        sqlInputs.setDbName(DB_NAME);
+        sqlInputs.setDbServer(DB_SERVER_IPV6_LITERAL);
+        sqlInputs.setDbPort(DB_PORT);
+//        sqlInputs.setDbUrls(new ArrayList<String>());
+        final List<String> dbUrls = verticaDatabase.setUp(sqlInputs);
+
+        assertEquals("jdbc:vertica://2001-0db8-85a3-0042-1000-8a2e-0370-7334.ipv6-literal.net:5433/dbName", dbUrls.get(0));
+        assertEquals(1, dbUrls.size());
+    }
+}

--- a/cs-database/src/test/java/io/cloudslang/content/database/utils/SQLInputsUtilsTest.java
+++ b/cs-database/src/test/java/io/cloudslang/content/database/utils/SQLInputsUtilsTest.java
@@ -116,6 +116,7 @@ public class SQLInputsUtilsTest {
         assertEquals(DEFAULT_PORT_MSSQL.intValue(), getOrDefaultDBPort(EMPTY, MSSQL_DB_TYPE));
         assertEquals(DEFAULT_PORT_MYSQL.intValue(), getOrDefaultDBPort(EMPTY, MYSQL_DB_TYPE));
         assertEquals(DEFAULT_PORT_PSQL.intValue(), getOrDefaultDBPort(EMPTY, POSTGRES_DB_TYPE));
+        assertEquals(DEFAULT_PORT_VERTICA.intValue(), getOrDefaultDBPort(EMPTY, VERTICA_DB_TYPE));
         assertEquals(DEFAULT_PORT_SYBASE.intValue(), getOrDefaultDBPort(EMPTY, SYBASE_DB_TYPE));
         assertEquals(DEFAULT_PORT_DB2.intValue(), getOrDefaultDBPort(EMPTY, DB2_DB_TYPE));
         assertEquals(DEFAULT_PORT_NETCOOL.intValue(), getOrDefaultDBPort(EMPTY, NETCOOL_DB_TYPE));
@@ -306,6 +307,7 @@ public class SQLInputsUtilsTest {
         assertThat(getDbClassForType(SYBASE_DB_TYPE), instanceOf(SybaseDatabase.class));
         assertThat(getDbClassForType(NETCOOL_DB_TYPE), instanceOf(NetcoolDatabase.class));
         assertThat(getDbClassForType(POSTGRES_DB_TYPE), instanceOf(PostgreSqlDatabase.class));
+        assertThat(getDbClassForType(VERTICA_DB_TYPE), instanceOf(VerticaDatabase.class));
         assertThat(getDbClassForType(DB2_DB_TYPE), instanceOf(DB2Database.class));
         assertThat(getDbClassForType(CUSTOM_DB_TYPE), instanceOf(CustomDatabase.class));
     }
@@ -322,7 +324,7 @@ public class SQLInputsUtilsTest {
         assertThat(getDbEnumForType(MSSQL_DB_TYPE), is(MSSQL));
         assertThat(getDbEnumForType(SYBASE_DB_TYPE), is(SYBASE));
         assertThat(getDbEnumForType(NETCOOL_DB_TYPE), is(NETCOOL));
-        assertThat(getDbEnumForType(POSTGRES_DB_TYPE), is(POSTGRESQL));
+        assertThat(getDbEnumForType(VERTICA_DB_TYPE), is(VERTICA));
         assertThat(getDbEnumForType(DB2_DB_TYPE), is(DB2));
         assertThat(getDbEnumForType(CUSTOM_DB_TYPE), is(CUSTOM));
     }

--- a/cs-database/src/test/java/io/cloudslang/content/database/utils/SQLInputsValidatorTest.java
+++ b/cs-database/src/test/java/io/cloudslang/content/database/utils/SQLInputsValidatorTest.java
@@ -187,6 +187,7 @@ public class SQLInputsValidatorTest {
         assertTrue(isValidDbType(DB2_DB_TYPE));
         assertTrue(isValidDbType(MYSQL_DB_TYPE));
         assertTrue(isValidDbType(POSTGRES_DB_TYPE));
+        assertTrue(isValidDbType(VERTICA_DB_TYPE));
         assertTrue(isValidDbType(CUSTOM_DB_TYPE));
     }
 
@@ -211,6 +212,7 @@ public class SQLInputsValidatorTest {
         assertFalse(isNotValidDbType(DB2_DB_TYPE));
         assertFalse(isNotValidDbType(MYSQL_DB_TYPE));
         assertFalse(isNotValidDbType(POSTGRES_DB_TYPE));
+        assertFalse(isNotValidDbType(VERTICA_DB_TYPE));
         assertFalse(isNotValidDbType(CUSTOM_DB_TYPE));
     }
 


### PR DESCRIPTION
Maven central does not yet contain a Vertica JDBC Driver. The driver can be downloaded here:
https://my.vertica.com/client_drivers/9.1.x/9.1.0-0/vertica-jdbc-9.1.0-0.jar

Install driver locally:
mvn --settings ~/CloudSlang/cslang/maven/conf/settings.xml install:install-file -Dfile=vertica-jdbc-9.1.0-0.jar -DgroupId=com.microfocus.vertica -DartifactId=vertica-jdbc -Dversion=9.1.0-0 -Dpackaging=jar
