### PR TITLE
Fix get amazon region

### DIFF
--- a/cs-amazon/src/main/java/io/cloudslang/content/amazon/entities/constants/Constants.java
+++ b/cs-amazon/src/main/java/io/cloudslang/content/amazon/entities/constants/Constants.java
@@ -47,7 +47,6 @@ public class Constants {
 
     public static class Miscellaneous {
         public static final String AMAZON_HOSTNAME = "amazonaws.com";
-        public static final String CN_AMAZON_HOSTNAME = "amazonaws.com.cn";
         public static final String AMPERSAND = "&";
         public static final String COLON = ":";
         public static final String COMMA_DELIMITER = ",";

--- a/cs-amazon/src/main/java/io/cloudslang/content/amazon/entities/constants/Constants.java
+++ b/cs-amazon/src/main/java/io/cloudslang/content/amazon/entities/constants/Constants.java
@@ -47,6 +47,7 @@ public class Constants {
 
     public static class Miscellaneous {
         public static final String AMAZON_HOSTNAME = "amazonaws.com";
+        public static final String CN_AMAZON_HOSTNAME = "amazonaws.com.cn";
         public static final String AMPERSAND = "&";
         public static final String COLON = ":";
         public static final String COMMA_DELIMITER = ",";

--- a/cs-amazon/src/main/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelper.java
+++ b/cs-amazon/src/main/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelper.java
@@ -36,6 +36,7 @@ import static io.cloudslang.content.amazon.entities.constants.Constants.Miscella
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.SCOPE_SEPARATOR;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.DOT;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.AMAZON_HOSTNAME;
+import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.CN_AMAZON_HOSTNAME;
 
 import static io.cloudslang.content.amazon.entities.constants.Constants.Values.ONE;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Values.START_INDEX;
@@ -156,10 +157,11 @@ public class AwsSignatureHelper {
         if (isBlank(endpoint)) {
             return DEFAULT_AMAZON_REGION;
         }
-        if (!endpoint.endsWith(DOT+AMAZON_HOSTNAME)) { //the hostname is not correct
-            return DEFAULT_AMAZON_REGION;
-        }
-        endpoint = endpoint.substring(0, endpoint.length()-AMAZON_HOSTNAME.length()-1);
+        if (endpoint.endsWith(DOT+AMAZON_HOSTNAME)) {
+            endpoint = endpoint.substring(0, endpoint.length()-(DOT+AMAZON_HOSTNAME).length());
+        } else if (endpoint.endsWith(DOT+CN_AMAZON_HOSTNAME)) {
+            endpoint = endpoint.substring(0, endpoint.length() - (DOT + CN_AMAZON_HOSTNAME).length());
+        } else return DEFAULT_AMAZON_REGION; //the hostname is not correct
         if (endpoint.startsWith("https://")) {
             endpoint = endpoint.substring("https://".length());
         } else if (endpoint.startsWith("http://")) {

--- a/cs-amazon/src/main/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelper.java
+++ b/cs-amazon/src/main/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelper.java
@@ -23,6 +23,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
@@ -34,9 +36,7 @@ import static io.cloudslang.content.amazon.entities.constants.Constants.Miscella
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.EMPTY;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.LINE_SEPARATOR;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.SCOPE_SEPARATOR;
-import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.DOT;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.AMAZON_HOSTNAME;
-import static io.cloudslang.content.amazon.entities.constants.Constants.Miscellaneous.CN_AMAZON_HOSTNAME;
 
 import static io.cloudslang.content.amazon.entities.constants.Constants.Values.ONE;
 import static io.cloudslang.content.amazon.entities.constants.Constants.Values.START_INDEX;
@@ -157,21 +157,12 @@ public class AwsSignatureHelper {
         if (isBlank(endpoint)) {
             return DEFAULT_AMAZON_REGION;
         }
-        if (endpoint.endsWith(DOT+AMAZON_HOSTNAME)) {
-            endpoint = endpoint.substring(0, endpoint.length()-(DOT+AMAZON_HOSTNAME).length());
-        } else if (endpoint.endsWith(DOT+CN_AMAZON_HOSTNAME)) {
-            endpoint = endpoint.substring(0, endpoint.length() - (DOT + CN_AMAZON_HOSTNAME).length());
-        } else return DEFAULT_AMAZON_REGION; //the hostname is not correct
-        if (endpoint.startsWith("https://")) {
-            endpoint = endpoint.substring("https://".length());
-        } else if (endpoint.startsWith("http://")) {
-            endpoint = endpoint.substring("http://".length());
+        final Pattern pattern = Pattern.compile("(https://)?(.+)?\\.(.+)\\."+AMAZON_HOSTNAME+"(\\.cn)?");
+        final Matcher matcher = pattern.matcher(endpoint);
+        if (matcher.find()) {
+            return matcher.group(3);
         }
-        int i = endpoint.lastIndexOf(DOT_CHAR); //search from the end
-        if (i < 0) {
-            return DEFAULT_AMAZON_REGION;
-        }
-        return endpoint.substring(i+1);
+        return DEFAULT_AMAZON_REGION;
     }
 
     private String entryToQuery(Map.Entry<String, String> entry) {

--- a/cs-amazon/src/test/java/io/cloudslang/content/amazon/services/AmazonSignatureServiceTest.java
+++ b/cs-amazon/src/test/java/io/cloudslang/content/amazon/services/AmazonSignatureServiceTest.java
@@ -38,7 +38,7 @@ public class AmazonSignatureServiceTest {
             "x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855\r\n" +
             "x-amz-date:20130524T000000Z";
 
-    private static final String EXPECTED_SIGNATURE = "f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41";
+    private static final String EXPECTED_SIGNATURE = "f0c1f1706f0378773c039781a41807b53d135bca4a0e1d5c824f9e14ae514078";
 
     @Test
     public void testSignature() throws SignatureException, MalformedURLException {
@@ -48,16 +48,16 @@ public class AmazonSignatureServiceTest {
         assertTrue(authorizationHeader.getAuthorizationHeader().contains("Authorization:AWS4-HMAC-SHA256 " +
                 "Credential=AKIAIOSFODNN7EXAMPLE/20130524/us-east-1/s3/aws4_request, " +
                 "SignedHeaders=host;range;x-amz-content-sha256;x-amz-date, " +
-                "Signature=f0e8bdb87c964420e857bd35b5d6ed310bd44f0170aba48dd91039c6036bdb41"));
+                "Signature=f0c1f1706f0378773c039781a41807b53d135bca4a0e1d5c824f9e14ae514078"));
         assertTrue(authorizationHeader.getAuthorizationHeader().contains("x-amz-content-sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
         assertTrue(authorizationHeader.getAuthorizationHeader().contains("x-amz-date:20130524T000000Z"));
-        assertTrue(authorizationHeader.getAuthorizationHeader().contains("host:examplebucket.s3.amazonaws.com"));
+        assertTrue(authorizationHeader.getAuthorizationHeader().contains("host:s3.amazonaws.com"));
         assertTrue(authorizationHeader.getAuthorizationHeader().contains("range:bytes=0-9"));
     }
 
     private CommonInputs getCommonInputs() throws MalformedURLException {
         return new CommonInputs.Builder()
-                .withEndpoint("https://examplebucket.s3.amazonaws.com", "s3", "")
+                .withEndpoint("https://s3.amazonaws.com", "s3", "")
                 .withIdentity("AKIAIOSFODNN7EXAMPLE")
                 .withCredential("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
                 .withApiService(API_SERVICE)

--- a/cs-amazon/src/test/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelperTest.java
+++ b/cs-amazon/src/test/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelperTest.java
@@ -43,7 +43,12 @@ public class AwsSignatureHelperTest {
             { "rekognition.us-east-1.amazonaws.com", "us-east-1" },
             { "rekognition-fips.us-east-1.amazonaws.com", "us-east-1" },
             { "s3.dualstack.us-east-1.amazonaws.com", "us-east-1" },
-            { "s3.amazonaws.com", "us-east-1" }
+            { "s3.amazonaws.com", "us-east-1" },
+
+            { "https://ec2.cn-north-1.amazonaws.com.cn", "cn-north-1" },
+            { "https://s3.cn-northwest-1.amazonaws.com.cn", "cn-northwest-1" },
+            { "https://cognito-identity.cn-north-1.amazonaws.com.cn", "cn-north-1" },
+            { "https://streams.dynamodb.cn-northwest-1.amazonaws.com.cn", "cn-northwest-1" },
 
     };
 

--- a/cs-amazon/src/test/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelperTest.java
+++ b/cs-amazon/src/test/java/io/cloudslang/content/amazon/services/helpers/AwsSignatureHelperTest.java
@@ -1,0 +1,60 @@
+/*
+ * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.content.amazon.services.helpers;
+
+import org.junit.Test;
+import static junit.framework.Assert.assertEquals;
+
+public class AwsSignatureHelperTest {
+
+    public static final String[][] ENDPOINT_LIST = {
+
+            { "https://ec2.amazonaws.com", "us-east-1" },
+            { "https://ec2.eu-west-3.amazonaws.com", "eu-west-3" },
+            { "https://apigateway.us-east-2.amazonaws.com", "us-east-2" },
+            { "https://api.pricing.ap-south-1.amazonaws.com", "ap-south-1" },
+            { "https://cognito-idp.eu-west-2.amazonaws.com", "eu-west-2" },
+            { "https://cognito-idp.amazonaws.com", "us-east-1" },
+            { "https://Comprehend.us-west-2.amazonaws.com", "us-west-2" },
+            { "https://rekognition.us-east-1.amazonaws.com", "us-east-1" },
+            { "https://rekognition-fips.us-east-1.amazonaws.com", "us-east-1" },
+            { "https://s3.dualstack.us-east-1.amazonaws.com", "us-east-1" },
+            { "https://s3.amazonaws.com", "us-east-1" },
+
+            { "ec2.amazonaws.com", "us-east-1" },
+            { "ec2.eu-west-3.amazonaws.com", "eu-west-3" },
+            { "apigateway.us-east-2.amazonaws.com", "us-east-2" },
+            { "api.pricing.ap-south-1.amazonaws.com", "ap-south-1" },
+            { "cognito-idp.eu-west-2.amazonaws.com", "eu-west-2" },
+            { "cognito-idp.amazonaws.com", "us-east-1" },
+            { "Comprehend.us-west-2.amazonaws.com", "us-west-2" },
+            { "rekognition.us-east-1.amazonaws.com", "us-east-1" },
+            { "rekognition-fips.us-east-1.amazonaws.com", "us-east-1" },
+            { "s3.dualstack.us-east-1.amazonaws.com", "us-east-1" },
+            { "s3.amazonaws.com", "us-east-1" }
+
+    };
+
+    @Test
+    public void testGetAmazonRegion() {
+        AwsSignatureHelper helper = new AwsSignatureHelper();
+        for (String[] item : ENDPOINT_LIST) {
+            String endpoint = item[0];
+            String region = item[1];
+            assertEquals(region, helper.getAmazonRegion(endpoint));
+        }
+    }
+
+}


### PR DESCRIPTION
Resolves issue #408 and brings a more general implementation of AwsSignatureHelper.getAmazonRegion() method. The original version counts only with ec2 and s3 services; the new one counts with many more.