### PR TITLE
Json operations validate

### DIFF
--- a/cs-json/pom.xml
+++ b/cs-json/pom.xml
@@ -124,6 +124,29 @@
             <artifactId>annotations</artifactId>
             <version>15.0</version>
         </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.fge/json-schema-validator -->
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>json-schema-validator</artifactId>
+            <version>2.2.6</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.fge/jackson-coreutils -->
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>jackson-coreutils</artifactId>
+            <version>1.8</version>
+        </dependency>
+        <!-- https://mvnrepository.com/artifact/com.github.fge/json-schema-core -->
+        <dependency>
+            <groupId>com.github.fge</groupId>
+            <artifactId>json-schema-core</artifactId>
+            <version>1.2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>io.cloudslang.content</groupId>
+            <artifactId>cs-http-client</artifactId>
+            <version>0.1.74</version>
+        </dependency>
 
     </dependencies>
 

--- a/cs-json/pom.xml
+++ b/cs-json/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+    * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
     * All rights reserved. This program and the accompanying materials
     * are made available under the terms of the Apache License v2.0 which accompany this distribution.
     *
@@ -207,7 +207,7 @@
                     </includes>
                     <!--Pass arguments using ${var} syntax in license.template file-->
                     <properties>
-                        <copyright.year>2017</copyright.year>
+                        <copyright.year>2018</copyright.year>
                     </properties>
                     <!--Custom mapping for java extensions-->
                     <useDefaultMapping>false</useDefaultMapping>

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/AddJsonPropertyToObject.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/AddJsonPropertyToObject.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/ArraySize.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/ArraySize.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/EditJson.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/EditJson.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/GetValueFromObject.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/GetValueFromObject.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/JsonPathQuery.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/JsonPathQuery.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/MergeArrays.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/MergeArrays.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.fasterxml.jackson.databind.JsonNode;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/RemoveEmptyElementAction.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/RemoveEmptyElementAction.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.actions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/ValidateJson.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/ValidateJson.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -46,15 +46,15 @@ public class ValidateJson {
      * Checks if a string is a valid JSON object and, optionally, if it validates against a JSON schema.
      */
 
-    @Action(name = "Validate JSON", description = "Checks if a JSON is valid."
+    @Action(name = "Validate JSON", description = VALIDATE_JSON_DESC
             , outputs = {
             @Output(OutputNames.RETURN_RESULT),
             @Output(OutputNames.RETURN_CODE),
             @Output(OutputNames.EXCEPTION)
     },
             responses = {
-                    @Response(text = ResponseNames.SUCCESS, field = OutputNames.RETURN_CODE, value = ReturnCodes.SUCCESS, matchType = MatchType.COMPARE_EQUAL, responseType = ResponseType.RESOLVED, description = "JSON is valid (return_code == '0')."),
-                    @Response(text = ResponseNames.FAILURE, field = OutputNames.RETURN_CODE, value = ReturnCodes.FAILURE, matchType = MatchType.COMPARE_EQUAL, responseType = ResponseType.ERROR, isOnFail = true, description = "An error has occurred while trying to validate the given JSON object.")
+                    @Response(text = ResponseNames.SUCCESS, field = OutputNames.RETURN_CODE, value = ReturnCodes.SUCCESS, matchType = MatchType.COMPARE_EQUAL, responseType = ResponseType.RESOLVED, description = VALIDATE_JSON_SUCCESS_DESC),
+                    @Response(text = ResponseNames.FAILURE, field = OutputNames.RETURN_CODE, value = ReturnCodes.FAILURE, matchType = MatchType.COMPARE_EQUAL, responseType = ResponseType.ERROR, isOnFail = true, description = VALIDATE_JSON_FAILURE_DESC)
             })
     public Map<String, String> execute(
             @Param(value = JSON_OBJECT, required = true, description = JSON_OBJECT_DESC) String jsonObject,

--- a/cs-json/src/main/java/io/cloudslang/content/json/actions/ValidateJson.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/actions/ValidateJson.java
@@ -1,0 +1,88 @@
+/*
+ * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.content.json.actions;
+
+import com.hp.oo.sdk.content.annotations.Action;
+import com.hp.oo.sdk.content.annotations.Output;
+import com.hp.oo.sdk.content.annotations.Param;
+import com.hp.oo.sdk.content.annotations.Response;
+import com.hp.oo.sdk.content.plugin.ActionMetadata.MatchType;
+import com.hp.oo.sdk.content.plugin.ActionMetadata.ResponseType;
+import io.cloudslang.content.constants.OtherValues;
+import io.cloudslang.content.constants.OutputNames;
+import io.cloudslang.content.constants.ResponseNames;
+import io.cloudslang.content.constants.ReturnCodes;
+import io.cloudslang.content.json.exceptions.JsonSchemaValidationException;
+import io.cloudslang.content.json.services.JsonService;
+
+import java.util.Map;
+
+import static io.cloudslang.content.json.services.JsonService.*;
+import static io.cloudslang.content.json.utils.Constants.Description.*;
+import static io.cloudslang.content.json.utils.Constants.InputNames.*;
+import static io.cloudslang.content.json.utils.Constants.ValidationMessages.EMPTY_JSON_PROVIDED;
+import static io.cloudslang.content.utils.OutputUtilities.getFailureResultsMap;
+
+/**
+ * Created by Daniel Manciu
+ * Date 20/07/2018.
+ */
+
+public class ValidateJson {
+
+    /**
+     * Checks if a string is a valid JSON object and, optionally, if it validates against a JSON schema.
+     */
+
+    @Action(name = "Validate JSON", description = "Checks if a JSON is valid."
+            , outputs = {
+            @Output(OutputNames.RETURN_RESULT),
+            @Output(OutputNames.RETURN_CODE),
+            @Output(OutputNames.EXCEPTION)
+    },
+            responses = {
+                    @Response(text = ResponseNames.SUCCESS, field = OutputNames.RETURN_CODE, value = ReturnCodes.SUCCESS, matchType = MatchType.COMPARE_EQUAL, responseType = ResponseType.RESOLVED, description = "JSON is valid (return_code == '0')."),
+                    @Response(text = ResponseNames.FAILURE, field = OutputNames.RETURN_CODE, value = ReturnCodes.FAILURE, matchType = MatchType.COMPARE_EQUAL, responseType = ResponseType.ERROR, isOnFail = true, description = "An error has occurred while trying to validate the given JSON object.")
+            })
+    public Map<String, String> execute(
+            @Param(value = JSON_OBJECT, required = true, description = JSON_OBJECT_DESC) String jsonObject,
+            @Param(value = JSON_SCHEMA, description = JSON_SCHEMA_DESC) String jsonSchema,
+            @Param(value = PROXY_HOST, description = PROXY_HOST_DESC) String proxyHost,
+            @Param(value = PROXY_PORT, description = PROXY_PORT_DESC) String proxyPort,
+            @Param(value = PROXY_USERNAME, description = PROXY_USERNAME_DESC) String proxyUsername,
+            @Param(value = PROXY_PASSWORD, encrypted = true, description = PROXY_PASSWORD_DESC) String proxyPassword
+    ) {
+        if (jsonObject == null || jsonObject.trim().equals(OtherValues.EMPTY_STRING)) {
+            return getFailureResultsMap(new Exception(EMPTY_JSON_PROVIDED));
+        }
+
+        jsonObject = JsonService.replaceSingleQuotesWithDoubleQuotes(jsonObject);
+
+        if (jsonSchema == null || jsonSchema.trim().equals(OtherValues.EMPTY_STRING)) {
+            return validateJsonResultMap(jsonObject);
+        }
+
+        String jsonSchemaObject;
+
+        try {
+            jsonSchemaObject = getJsonSchemaFromResource(jsonSchema, proxyHost, proxyPort, proxyUsername, proxyPassword);
+        } catch (JsonSchemaValidationException exception) {
+            return getFailureResultsMap(exception.getMessage());
+        }
+
+        return validateJsonAgainstSchemaResultMap(jsonObject, jsonSchemaObject);
+    }
+
+}

--- a/cs-json/src/main/java/io/cloudslang/content/json/exceptions/JsonSchemaValidationException.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/exceptions/JsonSchemaValidationException.java
@@ -12,16 +12,16 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+package io.cloudslang.content.json.exceptions;
 
-package io.cloudslang.content.json.utils;
+public class JsonSchemaValidationException extends Exception {
 
-import io.cloudslang.content.constants.ExceptionValues;
+    public JsonSchemaValidationException(String message) {
+        super(message);
+    }
 
-/**
- * Created by victor on 9/12/16.
- */
-public final class JsonExceptionValues extends ExceptionValues {
-    public static final String INVALID_JSONOBJECT = "Invalid jsonObject provided!";
-    public static final String INVALID_JSONPATH = "Invalid jsonPath provided!";
-    public static final String INVALID_JSONSCHEMA = "Invalid jsonSchema provided!";
+    public JsonSchemaValidationException(Exception ex) {
+        super(ex);
+    }
 }
+

--- a/cs-json/src/main/java/io/cloudslang/content/json/exceptions/JsonSchemaValidationException.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/exceptions/JsonSchemaValidationException.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cs-json/src/main/java/io/cloudslang/content/json/exceptions/RemoveEmptyElementException.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/exceptions/RemoveEmptyElementException.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.exceptions;
 
 /**

--- a/cs-json/src/main/java/io/cloudslang/content/json/services/JsonService.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/services/JsonService.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.services;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/ActionsEnum.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/ActionsEnum.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.utils;
 
 /**

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/Constants.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/Constants.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.utils;
 
 /**
@@ -48,6 +47,9 @@ public final class Constants {
         public static final String PROXY_PORT_DESC = "The proxy port for the Get request.";
         public static final String PROXY_USERNAME_DESC = "The username for connecting via proxy.";
         public static final String PROXY_PASSWORD_DESC = "The password for connecting via proxy.";
+        public static final String VALIDATE_JSON_DESC = "Checks if a JSON is valid and, optionally, if it validates against a JSON SCHEMA.";
+        public static final String VALIDATE_JSON_SUCCESS_DESC = "JSON is valid (return_code == '0').";
+        public static final String VALIDATE_JSON_FAILURE_DESC = "An error has occurred while trying to validate the given JSON object.";
     }
 
     public static final class ValidationMessages {

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/Constants.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/Constants.java
@@ -23,6 +23,7 @@ public final class Constants {
 
     public static final class InputNames extends io.cloudslang.content.constants.InputNames {
         public static final String JSON_OBJECT = "jsonObject";
+        public static final String JSON_SCHEMA = "jsonSchema";
         public static final String NEW_PROPERTY_NAME = "newPropertyName";
         public static final String NEW_PROPERTY_VALUE = "newPropertyValue";
         public static final String OBJECT = "object";
@@ -33,6 +34,28 @@ public final class Constants {
         public static final String NAME = "name";
         public static final String VALUE = "value";
         public static final String VALIDATE_VALUE = "validateValue";
+        public static final String PROXY_HOST = "proxyHost";
+        public static final String PROXY_PORT = "proxyPort";
+        public static final String PROXY_USERNAME = "proxyUsername";
+        public static final String PROXY_PASSWORD = "proxyPassword";
+        public static final String HTTP_GET = "get";
+    }
+
+    public static final class Description {
+        public static final String JSON_OBJECT_DESC = "The JSON to validate.";
+        public static final String JSON_SCHEMA_DESC = "The JSON schema to validate against. Can also be an URL or a file path.";
+        public static final String PROXY_HOST_DESC = "The proxy host for the Get request.";
+        public static final String PROXY_PORT_DESC = "The proxy port for the Get request.";
+        public static final String PROXY_USERNAME_DESC = "The username for connecting via proxy.";
+        public static final String PROXY_PASSWORD_DESC = "The password for connecting via proxy.";
+    }
+
+    public static final class ValidationMessages {
+        public static final String VALID_JSON = "Valid JSON";
+        public static final String EMPTY_JSON_PROVIDED = "Empty JSON string provided";
+        public static final String EMPTY_SCHEMA_URL = "Empty schema returned by request";
+        public static final String VALID_JSON_AGAINST_SCHEMA = "The JSON validates against the schema";
+        public static final String INVALID_JSON_AGAINST_SCHEMA = "The JSON does not validate against the schema";
     }
 
     static final class EditJsonOperations {
@@ -42,4 +65,5 @@ public final class Constants {
         static final String DELETE_ACTION = "delete";
         static final String ADD_ACTION = "add";
     }
+
 }

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/JsonExceptionValues.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/JsonExceptionValues.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.utils;
 
 import io.cloudslang.content.constants.ExceptionValues;

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/JsonUtils.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/JsonUtils.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.utils;
 
 import com.fasterxml.jackson.core.JsonParser;

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/StringUtils.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/StringUtils.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,7 +12,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 package io.cloudslang.content.json.utils;
 
 import static io.cloudslang.content.constants.OtherValues.EMPTY_STRING;

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/ValidationUtils.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/ValidationUtils.java
@@ -1,5 +1,5 @@
 /*
- * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *

--- a/cs-json/src/main/java/io/cloudslang/content/json/utils/ValidationUtils.java
+++ b/cs-json/src/main/java/io/cloudslang/content/json/utils/ValidationUtils.java
@@ -1,0 +1,182 @@
+/*
+ * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.content.json.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.github.fge.jackson.JsonLoader;
+import com.github.fge.jsonschema.core.exceptions.ProcessingException;
+import com.github.fge.jsonschema.core.report.ProcessingMessage;
+import com.github.fge.jsonschema.core.report.ProcessingReport;
+import com.github.fge.jsonschema.main.JsonSchema;
+import com.github.fge.jsonschema.main.JsonSchemaFactory;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
+
+public class ValidationUtils {
+
+    public static final String JSON_V4_SCHEMA_IDENTIFIER = "http://json-schema.org/draft-04/schema#";
+    public static final String JSON_SCHEMA_IDENTIFIER_ELEMENT = "$schema";
+
+
+    public static JsonNode getJsonNode(String jsonText)
+            throws IOException {
+        return JsonLoader.fromString(jsonText);
+    }
+
+    public static JsonNode getJsonNode(File jsonFile)
+            throws IOException {
+        return JsonLoader.fromFile(jsonFile);
+    }
+
+    public static JsonNode getJsonNode(URL url)
+            throws IOException {
+        return JsonLoader.fromURL(url);
+    }
+
+    public static JsonNode getJsonNodeFromResource(String resource)
+            throws IOException {
+        return JsonLoader.fromResource(resource);
+    }
+
+    public static JsonSchema getSchemaNode(String schemaText)
+            throws IOException, ProcessingException {
+        final JsonNode schemaNode = getJsonNode(schemaText);
+        return _getSchemaNode(schemaNode);
+    }
+
+    public static JsonSchema getSchemaNode(File schemaFile)
+            throws IOException, ProcessingException {
+        final JsonNode schemaNode = getJsonNode(schemaFile);
+        return _getSchemaNode(schemaNode);
+    }
+
+    public static JsonSchema getSchemaNode(URL schemaFile)
+            throws IOException, ProcessingException {
+        final JsonNode schemaNode = getJsonNode(schemaFile);
+        return _getSchemaNode(schemaNode);
+    }
+
+    public static JsonSchema getSchemaNodeFromResource(String resource)
+            throws IOException, ProcessingException {
+        final JsonNode schemaNode = getJsonNodeFromResource(resource);
+        return _getSchemaNode(schemaNode);
+    }
+
+    public static void validateJson(JsonSchema jsonSchemaNode, JsonNode jsonNode)
+            throws ProcessingException {
+        ProcessingReport report = jsonSchemaNode.validate(jsonNode);
+        if (!report.isSuccess()) {
+            for (ProcessingMessage processingMessage : report) {
+                throw new ProcessingException(processingMessage);
+            }
+        }
+    }
+
+    public static boolean isJsonValid(JsonSchema jsonSchemaNode, JsonNode jsonNode) throws ProcessingException {
+        ProcessingReport report = jsonSchemaNode.validate(jsonNode);
+        return report.isSuccess();
+    }
+
+    public static boolean isJsonValid(String schemaText, String jsonText) throws ProcessingException, IOException {
+        final JsonSchema schemaNode = getSchemaNode(schemaText);
+        final JsonNode jsonNode = getJsonNode(jsonText);
+        return isJsonValid(schemaNode, jsonNode);
+    }
+
+    public static boolean isJsonValid(File schemaFile, File jsonFile) throws ProcessingException, IOException {
+        final JsonSchema schemaNode = getSchemaNode(schemaFile);
+        final JsonNode jsonNode = getJsonNode(jsonFile);
+        return isJsonValid(schemaNode, jsonNode);
+    }
+
+    public static boolean isJsonValid(File schemaFile, String jsonText) throws ProcessingException, IOException {
+        final JsonSchema schemaNode = getSchemaNode(schemaFile);
+        final JsonNode jsonNode = getJsonNode(jsonText);
+        return isJsonValid(schemaNode, jsonNode);
+    }
+
+    public static boolean isJsonValid(URL schemaURL, URL jsonURL) throws ProcessingException, IOException {
+        final JsonSchema schemaNode = getSchemaNode(schemaURL);
+        final JsonNode jsonNode = getJsonNode(jsonURL);
+        return isJsonValid(schemaNode, jsonNode);
+    }
+
+    public static void validateJson(String schemaText, String jsonText) throws IOException, ProcessingException {
+        final JsonSchema schemaNode = getSchemaNode(schemaText);
+        final JsonNode jsonNode = getJsonNode(jsonText);
+        validateJson(schemaNode, jsonNode);
+    }
+
+    public static void validateJson(File schemaFile, File jsonFile) throws IOException, ProcessingException {
+        final JsonSchema schemaNode = getSchemaNode(schemaFile);
+        final JsonNode jsonNode = getJsonNode(jsonFile);
+        validateJson(schemaNode, jsonNode);
+    }
+
+    public static void validateJson(URL schemaDocument, URL jsonDocument) throws IOException, ProcessingException {
+        final JsonSchema schemaNode = getSchemaNode(schemaDocument);
+        final JsonNode jsonNode = getJsonNode(jsonDocument);
+        validateJson(schemaNode, jsonNode);
+    }
+
+    public static void validateJsonResource(String schemaResource, String jsonResource) throws IOException, ProcessingException {
+        final JsonSchema schemaNode = getSchemaNode(schemaResource);
+        final JsonNode jsonNode = getJsonNodeFromResource(jsonResource);
+        validateJson(schemaNode, jsonNode);
+    }
+
+    private static JsonSchema _getSchemaNode(JsonNode jsonNode)
+            throws ProcessingException {
+        final JsonNode schemaIdentifier = jsonNode.get(JSON_SCHEMA_IDENTIFIER_ELEMENT);
+        if (null == schemaIdentifier) {
+            ((ObjectNode) jsonNode).put(JSON_SCHEMA_IDENTIFIER_ELEMENT, JSON_V4_SCHEMA_IDENTIFIER);
+        }
+
+        final JsonSchemaFactory factory = JsonSchemaFactory.byDefault();
+        return factory.getJsonSchema(jsonNode);
+    }
+
+    public static boolean isValidUrl(String url) {
+        URL u;
+
+        try {
+            u = new URL(url);
+        } catch (MalformedURLException e) {
+            return false;
+        }
+
+        try {
+            u.toURI();
+        } catch (URISyntaxException e) {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean isJsonSchemaEmpty(String jsonSchema) {
+        return jsonSchema.equals("{}");
+    }
+
+    public static String replaceSingleQuotesWithDoubleQuotes(String jsonObject) {
+        return jsonObject.replace("\'", "\"");
+    }
+
+}

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/AddJsonPropertyToObjectTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/AddJsonPropertyToObjectTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/ArraySizeTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/ArraySizeTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/EditJsonTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/EditJsonTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/GetValueFromObjectTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/GetValueFromObjectTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/JsonPathQueryTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/JsonPathQueryTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/MergeArraysTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/MergeArraysTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/RemoveEmptyElementTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/RemoveEmptyElementTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/ValidateJsonTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/ValidateJsonTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/io/cloudslang/content/json/actions/ValidateJsonTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/actions/ValidateJsonTest.java
@@ -1,0 +1,273 @@
+/*
+ * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.cloudslang.content.json.actions;
+
+import io.cloudslang.content.constants.OtherValues;
+import io.cloudslang.content.constants.OutputNames;
+import io.cloudslang.content.constants.ReturnCodes;
+import io.cloudslang.content.json.utils.ValidationUtils;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static io.cloudslang.content.json.utils.Constants.ValidationMessages.*;
+import static org.junit.Assert.*;
+
+/**
+ * Created by Daniel Manciu
+ * Date 24/7/2018
+ */
+public class ValidateJsonTest {
+
+    private static ValidateJson validateJson = new ValidateJson();
+
+    @Test
+    public void testValidateJsonSimpleSuccess() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\"}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertEquals(VALID_JSON, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+        assertNull(result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testValidateJsonComplexSuccess() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\",\n" +
+                "  \"address\": {\n" +
+                "    \"street_address\": \"3200 Mount Vernon Memorial Highway\",\n" +
+                "    \"city\": \"Mount Vernon\",\n" +
+                "    \"state\": \"Virginia\",\n" +
+                "    \"country\": \"United States\"\n" +
+                "  }\n" +
+                "}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertEquals(VALID_JSON, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+        assertNull(result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testValidateJsonSimpleQuotesSuccess() {
+        String jsonObject = "{\n" +
+                "  \'first_name\': \'George\',\n" +
+                "  \'last_name\': \'Washington\',\n" +
+                "  \'birthday\': \'22-02-1732\'}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertEquals(VALID_JSON, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+        assertNull(result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testValidateJsonExtraDataFailure() {
+        String jsonObject = "{\"firstName\":\"Darth\", \"lastName\":\"Vader\"}, {\"firstName\":\"Luke\", \"lastName\":\"Skywalker\"}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertTrue(result.get(OutputNames.EXCEPTION).contains("input has trailing data after first JSON Text"));
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+        assertEquals(result.get(OutputNames.RETURN_RESULT), result.get(OutputNames.EXCEPTION));
+    }
+
+
+    @Test
+    public void testNullInputFailure() {
+        final Map<String, String> result = validateJson.execute(null, null, null, null, null, null);
+        assertEquals(EMPTY_JSON_PROVIDED, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+    }
+
+    @Test
+    public void testEmptyJsonStringFailure() {
+        String jsonObject = "";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertEquals(EMPTY_JSON_PROVIDED, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+    }
+
+    @Test
+    public void testEmptyKeyJsonFailure() {
+        String jsonObject = "{\"\" : \"empty key\"}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertEquals(VALID_JSON, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+        assertNull(result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testDuplicateKeyJsonFailure() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"last_name\": \"Daniel\"}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertTrue(result.get(OutputNames.EXCEPTION).contains("Duplicate field"));
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+        assertEquals(result.get(OutputNames.RETURN_RESULT), result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testUnquotedCharacterJsonFailure() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington,\n" +
+                "  \"birthday\": \"22-02-1732\"}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, null, null, null, null, null);
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+        assertTrue(result.get(OutputNames.EXCEPTION).contains("Illegal unquoted character"));
+        assertEquals(result.get(OutputNames.RETURN_RESULT), result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testEmptySchemaSuccess() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\"}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, OtherValues.EMPTY_STRING, null, null, null, null);
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+    }
+
+    @Test
+    public void testValidateJsonAgainstSchemaSuccess() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\",\n" +
+                "  \"address\": {\n" +
+                "    \"street_address\": \"3200 Mount Vernon Memorial Highway\",\n" +
+                "    \"city\": \"Mount Vernon\",\n" +
+                "    \"state\": \"Virginia\",\n" +
+                "    \"country\": \"United States\"\n" +
+                "  }\n" +
+                "}";
+
+        String jsonSchemaObject = "{\n" +
+                "  \"type\": \"object\",\n" +
+                "  \"properties\": {\n" +
+                "    \"first_name\": { \"type\": \"string\" },\n" +
+                "    \"last_name\": { \"type\": \"string\" },\n" +
+                "    \"birthday\": { \"type\": \"string\" },\n" +
+                "    \"address\": {\n" +
+                "      \"type\": \"object\",\n" +
+                "      \"properties\": {\n" +
+                "        \"street_address\": { \"type\": \"string\" },\n" +
+                "        \"city\": { \"type\": \"string\" },\n" +
+                "        \"state\": { \"type\": \"string\" },\n" +
+                "        \"country\": { \"type\" : \"string\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, jsonSchemaObject, null, null, null, null);
+        assertEquals(VALID_JSON_AGAINST_SCHEMA, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+        assertNull(result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testValidateJsonAgainstSchemaFailure() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": 1,\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\",\n" +
+                "  \"address\": {\n" +
+                "    \"street_address\": \"3200 Mount Vernon Memorial Highway\",\n" +
+                "    \"city\": \"Mount Vernon\",\n" +
+                "    \"state\": \"Virginia\",\n" +
+                "    \"country\": \"United States\"\n" +
+                "  }\n" +
+                "}";
+
+        String jsonSchemaObject = "{\n" +
+                "  \"type\": \"object\",\n" +
+                "  \"properties\": {\n" +
+                "    \"first_name\": { \"type\": \"string\" },\n" +
+                "    \"last_name\": { \"type\": \"string\" },\n" +
+                "    \"birthday\": { \"type\": \"string\" },\n" +
+                "    \"address\": {\n" +
+                "      \"type\": \"object\",\n" +
+                "      \"properties\": {\n" +
+                "        \"street_address\": { \"type\": \"string\" },\n" +
+                "        \"city\": { \"type\": \"string\" },\n" +
+                "        \"state\": { \"type\": \"string\" },\n" +
+                "        \"country\": { \"type\" : \"string\" }\n" +
+                "      }\n" +
+                "    }\n" +
+                "  }\n" +
+                "}";
+
+        final Map<String, String> result = validateJson.execute(jsonObject, jsonSchemaObject, null, null, null, null);
+        assertEquals(INVALID_JSON_AGAINST_SCHEMA, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+    }
+
+    @Test
+    public void testValidateJsonWithSchemaFromFile() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\",\n" +
+                "  \"address\": {\n" +
+                "    \"street_address\": \"3200 Mount Vernon Memorial Highway\",\n" +
+                "    \"city\": \"Mount Vernon\",\n" +
+                "    \"state\": \"Virginia\",\n" +
+                "    \"country\": \"United States\"\n" +
+                "  }\n" +
+                "}";
+
+        String jsonSchemaFilePath = System.getProperty("user.dir") + "\\src\\test\\java\\resources\\test_valid_json_schema.json";
+        final Map<String, String> result = validateJson.execute(jsonObject, jsonSchemaFilePath, null, null, null, null);
+        assertEquals(VALID_JSON_AGAINST_SCHEMA, result.get(OutputNames.RETURN_RESULT));
+        assertEquals(ReturnCodes.SUCCESS, result.get(OutputNames.RETURN_CODE));
+        assertNull(result.get(OutputNames.EXCEPTION));
+    }
+
+    @Test
+    public void testInvalidSchemaFromFile() {
+        String jsonObject = "{\n" +
+                "  \"first_name\": \"George\",\n" +
+                "  \"last_name\": \"Washington\",\n" +
+                "  \"birthday\": \"22-02-1732\",\n" +
+                "  \"address\": {\n" +
+                "    \"street_address\": \"3200 Mount Vernon Memorial Highway\",\n" +
+                "    \"city\": \"Mount Vernon\",\n" +
+                "    \"state\": \"Virginia\",\n" +
+                "    \"country\": \"United States\"\n" +
+                "  }\n" +
+                "}";
+
+        String jsonSchemaFilePath = System.getProperty("user.dir") + "\\src\\test\\java\\resources\\test_invalid_json_schema.json";
+        final Map<String, String> result = validateJson.execute(jsonObject, jsonSchemaFilePath, null, null, null, null);
+        assertEquals(ReturnCodes.FAILURE, result.get(OutputNames.RETURN_CODE));
+        assertTrue(result.get(OutputNames.EXCEPTION).contains("invalid JSON Schema"));
+        assertEquals(result.get(OutputNames.RETURN_RESULT), result.get(OutputNames.EXCEPTION));
+    }
+
+}

--- a/cs-json/src/test/java/io/cloudslang/content/json/services/JsonServiceTest.java
+++ b/cs-json/src/test/java/io/cloudslang/content/json/services/JsonServiceTest.java
@@ -1,4 +1,18 @@
 /*
+ * (c) Copyright 2018 EntIT Software LLC, a Micro Focus company, L.P.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/*
  * (c) Copyright 2017 EntIT Software LLC, a Micro Focus company, L.P.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.

--- a/cs-json/src/test/java/resources/test_invalid_json_schema.json
+++ b/cs-json/src/test/java/resources/test_invalid_json_schema.json
@@ -1,0 +1,4 @@
+{
+  "type": "object",
+  "properties": "properties"
+}

--- a/cs-json/src/test/java/resources/test_valid_json_schema.json
+++ b/cs-json/src/test/java/resources/test_valid_json_schema.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "properties": {
+    "first_name": {
+      "type": "string"
+    },
+    "last_name": {
+      "type": "string"
+    },
+    "birthday": {
+      "type": "string"
+    },
+    "address": {
+      "type": "object",
+      "properties": {
+        "street_address": {
+          "type": "string"
+        },
+        "city": {
+          "type": "string"
+        },
+        "state": {
+          "type": "string"
+        },
+        "country": {
+          "type": "string"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Added ValidateJson operation: 
Operation supports schema from string, file, url
Added dependency json-schema-validator version 2.2.6
Added dependency jackson-coreutils version 1.8
Added dependency json-schema-core version 1.2.5
Added dependency cs-http-client version 0.1.74
Added tests