### PR TITLE
changed sqljdbc4 dependency to mssql-jdbc 6.2.2.jre7 because of criti…

### DIFF
--- a/cs-database/pom.xml
+++ b/cs-database/pom.xml
@@ -137,9 +137,9 @@
         </dependency>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
-            <artifactId>sqljdbc4</artifactId>
-            <version>4.0</version>
-            <scope>runtime</scope>
+            <artifactId>mssql-jdbc</artifactId>
+            <version>6.2.2.jre7</version>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.oracle</groupId>


### PR DESCRIPTION
issue id: 336998
[STAT] Multiple Critical vulnerabilities in cs-base-cp-1.2.3.jar

changed sqljdbc4 dependency to mssql-jdbc 6.2.2.jre7 because of critical vulnerabilities

TESTING DONE:
automation runs as expected