### PR TITLE
Fixed scientific notation bug

### DIFF
--- a/cs-excel/src/main/java/io/cloudslang/content/excel/services/GetCellService.java
+++ b/cs-excel/src/main/java/io/cloudslang/content/excel/services/GetCellService.java
@@ -147,7 +147,7 @@ public class GetCellService {
                             //Fix for QCIM1D248808
                             if (!cell.toString().isEmpty() && isNumericCell(cell)) {
                                 double aCellValue = cell.getNumericCellValue();
-                                cellString = round(Double.toString(aCellValue));
+                                cellString = Double.toString(aCellValue);
                             }
                             result.append(cellString);
                         }


### PR DESCRIPTION
Fixed a bug in which numeric numbers where displayed in scientific notation (e.g. 1E+3) instead of standard notation (e.g. 1000)