### PR TITLE
Reverted from 'fromAddress' input name to 'from' input name

### DIFF
--- a/cs-mail/src/main/java/io/cloudslang/content/mail/actions/SendMailAction.java
+++ b/cs-mail/src/main/java/io/cloudslang/content/mail/actions/SendMailAction.java
@@ -114,7 +114,7 @@ public class SendMailAction {
             @Param(value = InputNames.HOSTNAME, required = true) String hostname,
             @Param(value = InputNames.PORT, required = true) String port,
             @Param(value = InputNames.HTML_EMAIL) String htmlEmail,
-            @Param(value = InputNames.FROM_ADDRESS, required = true) String from,
+            @Param(value = InputNames.FROM, required = true) String from,
             @Param(value = InputNames.TO, required = true) String to,
             @Param(value = InputNames.CC) String cc,
             @Param(value = InputNames.BCC) String bcc,

--- a/cs-mail/src/main/java/io/cloudslang/content/mail/constants/InputNames.java
+++ b/cs-mail/src/main/java/io/cloudslang/content/mail/constants/InputNames.java
@@ -44,7 +44,7 @@ public final class InputNames {
     public static final String VERIFY_CERTIFICATE = "verifyCertificate";
     public static final String HOSTNAME = "hostname";
     public static final String HTML_EMAIL = "htmlEmail";
-    public static final String FROM_ADDRESS = "fromAddress";
+    public static final String FROM = "from";
     public static final String TO = "to";
     public static final String CC = "cc";
     public static final String BCC = "bcc";


### PR DESCRIPTION
**User Story ID**
720739

**Description**
Solved a backwards compatibility issue by reverting the name of an input on _Send Mail_ operation to its original name as stated in this PR's title.