### PR TITLE
Reverted cs-xml version from RC1 to SNAPSHOT as jenkins job failed

### DIFF
--- a/cs-xml/pom.xml
+++ b/cs-xml/pom.xml
@@ -20,7 +20,7 @@
 
     <groupId>io.cloudslang.content</groupId>
     <artifactId>cs-xml</artifactId>
-    <version>0.0.12-RC1</version>
+    <version>0.0.12-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -38,7 +38,7 @@
         <connection>scm:git:https://CloudSlang/cs-actions.git</connection>
         <developerConnection>scm:git:git@github.com:CloudSlang/cs-actions.git</developerConnection>
         <url>https://github.com/CloudSlang/cs-actions.git</url>
-        <tag>cs-xml-0.0.12-RC1</tag>
+        <tag>master</tag>
     </scm>
 
     <developers>


### PR DESCRIPTION
Jenkins release cs-xml-RC1 failed and the version was not changed back to SNPASHOT, so any other releases are impossible if version is not changed back manually.