### PR TITLE
fix for issue - 867403 : Issue with OO base content 1.18.0 send mail …

### DIFF
--- a/cs-mail/src/main/java/io/cloudslang/content/mail/services/SendMailService.java
+++ b/cs-mail/src/main/java/io/cloudslang/content/mail/services/SendMailService.java
@@ -189,11 +189,17 @@ public class SendMailService {
 
             msg.saveChanges();
 
-            if (!StringUtils.isEmpty(input.getUsername())) {
+            if (!input.isEnableTLS() && !StringUtils.isEmpty(input.getUsername())) {
+                transport = session.getTransport(SmtpPropNames.SMTP);
+                transport.connect(input.getHostname(), input.getPort(), input.getUsername(), input.getPassword());
+                transport.sendMessage(msg, msg.getAllRecipients());
+            }
+            else if (input.isEnableTLS() && !StringUtils.isEmpty(input.getUsername())) {
                 transport = session.getTransport(SmtpPropNames.SMTP + SecurityConstants.SECURE_SUFFIX);
                 transport.connect(input.getHostname(), input.getPort(), input.getUsername(), input.getPassword());
                 transport.sendMessage(msg, msg.getAllRecipients());
-            } else {
+            }
+            else {
                 Transport.send(msg);
             }
             result.put(OutputNames.RETURN_RESULT, Constants.MAIL_WAS_SENT);

--- a/cs-mail/src/test/java/io/cloudslang/content/mail/services/SendMailServiceTest.java
+++ b/cs-mail/src/test/java/io/cloudslang/content/mail/services/SendMailServiceTest.java
@@ -225,7 +225,7 @@ public class SendMailServiceTest {
      */
     @Test
     public void testExecuteWithHeaders() throws Exception {
-        Mockito.doReturn(transportMock).when(sessionMock).getTransport(SMTP_PROTOCOL + SecurityConstants.SECURE_SUFFIX);
+        Mockito.doReturn(transportMock).when(sessionMock).getTransport(SMTP_PROTOCOL);
 
         inputBuilder.hostname(SMTP_HOSTANME)
                 .port(PORT)
@@ -295,7 +295,7 @@ public class SendMailServiceTest {
      */
     @Test
     public void testExecuteGoesToSuccessScenario1() throws Exception {
-        Mockito.doReturn(transportMock).when(sessionMock).getTransport(SMTP_PROTOCOL + SecurityConstants.SECURE_SUFFIX);
+        Mockito.doReturn(transportMock).when(sessionMock).getTransport(SMTP_PROTOCOL);
         Mockito.doNothing().when(transportMock).connect(SMTP_HOSTANME, INT_PORT, USER, PASSWORD);
         Mockito.doNothing().when(transportMock).sendMessage(Matchers.<SMTPMessage>any(), Matchers.<Address[]>any());
         Mockito.doReturn(addresses).when(smtpMessageMock).getAllRecipients();
@@ -319,7 +319,7 @@ public class SendMailServiceTest {
         verify(propertiesMock).put(eq(SMTP_USER_CONFIG), eq(USER));
         verify(propertiesMock).put(eq(SMTP_PASSWORD_CONFIG), eq(PASSWORD));
         verify(propertiesMock).put(eq(SMTP_AUTH_CONFIG), eq("true"));
-        verify(sessionMock).getTransport(SMTP_PROTOCOL + SecurityConstants.SECURE_SUFFIX);
+        verify(sessionMock).getTransport(SMTP_PROTOCOL);
         verify(transportMock).connect(SMTP_HOSTANME, INT_PORT, USER, PASSWORD);
         verify(transportMock).sendMessage(Matchers.<SMTPMessage>any(), Matchers.<Address[]>any());
         verify(mimeBodyPartMock).setContent(BODY, TEXT_PLAIN + CHARSET_CST + DEFAULT_CHARACTERSET);


### PR DESCRIPTION
fix for issue - 867403 : Issue with OO base content 1.18.0 send mail operation

updated the send mail operation code to check whether TLS is enabled or disabled and then accordingly use SMTPS or SMTP instead of directly using SMTPS. 

Fix was provided to the customer and customer had tested it and after everything worked fine, asked for the signed build. 

@florinAndrei1991 , @BoicuAlexandra  please review