### PR TITLE
changed the versioning for cs-sitescope

### DIFF
--- a/cs-sitescope/pom.xml
+++ b/cs-sitescope/pom.xml
@@ -21,7 +21,7 @@
 
     <groupId>io.cloudslang.content</groupId>
     <artifactId>cs-sitescope</artifactId>
-    <version>0.0.1-RC7</version>
+    <version>0.0.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>
@@ -39,7 +39,7 @@
         <connection>scm:git:https://CloudSlang/cs-actions.git</connection>
         <developerConnection>scm:git:git@github.com:CloudSlang/cs-actions.git</developerConnection>
         <url>https://github.com/CloudSlang/cs-actions.git</url>
-        <tag>cs-sitescope-0.0.1-RC7</tag>
+        <tag>master</tag>
     </scm>
 
     <distributionManagement>


### PR DESCRIPTION
removed extra copyright

Merge branch 'master' of github.com:CloudSlang/cs-actions into delete_monitor
