### PR TITLE
upgrade bcprov to 1.65

### DIFF
--- a/cs-ssh/pom.xml
+++ b/cs-ssh/pom.xml
@@ -121,7 +121,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>1.65</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>


### PR DESCRIPTION
upgrade bcprov to 1.65
Signed-off-by: Marius Petrovan <marius.petrovan@microfocus.com>