### PR TITLE
Updated json-path from 2.2.0 to 2.6.0

### DIFF
--- a/cs-microfocus-sitescope/pom.xml
+++ b/cs-microfocus-sitescope/pom.xml
@@ -124,7 +124,7 @@
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
-            <version>2.2.0</version>
+            <version>2.6.0</version>
         </dependency>
         <dependency>
             <groupId>junit</groupId>


### PR DESCRIPTION
fix for jackson-databind and json-smart security vulnerabilities