### PR TITLE
updated json-smart from 2.5.0 to 2.5.2 

### DIFF
--- a/cs-microsoft-ad/pom.xml
+++ b/cs-microsoft-ad/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    * Copyright 2021-2024 Open Text
+    * Copyright 2021-2025 Open Text
     * This program and the accompanying materials
     * are made available under the terms of the Apache License v2.0 which accompany this distribution.
     *
@@ -15,8 +15,8 @@
     * limitations under the License.
 
 -->
-
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.cloudslang.content</groupId>
@@ -109,6 +109,10 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcpkix-jdk18on</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -125,6 +129,17 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
         </dependency>
 
         <!--HTTP CLIENT-->
@@ -247,7 +262,7 @@
                         <include>pom.xml</include>
                     </includes>
                     <properties>
-                        <copyright.year>2021-2024</copyright.year>
+                        <copyright.year>2021-2025</copyright.year>
                     </properties>
                     <useDefaultMapping>false</useDefaultMapping>
                     <mapping>

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/authorization/GetAuthorizationToken.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/authorization/GetAuthorizationToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.actions.authorization;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/AssignUserLicense.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/AssignUserLicense.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.licenseManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/GetUserLicenseDetails.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/GetUserLicenseDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.licenseManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/ListAvailableSkus.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/ListAvailableSkus.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.licenseManagement;
 
 import com.google.gson.JsonArray;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/RemoveUserLicense.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/licenseManagement/RemoveUserLicense.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.licenseManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/ChangeUserPassword.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/ChangeUserPassword.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/CreateUser.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/CreateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/DeleteUser.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/DeleteUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/DisableUser.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/DisableUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/EnableUser.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/EnableUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/IsUserEnabled.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/IsUserEnabled.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/IsUserInGroup.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/IsUserInGroup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.google.gson.JsonArray;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/ResetUserPassword.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/ResetUserPassword.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/UpdateUser.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/actions/userManagement/UpdateUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.actions.userManagement;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/AssignUserLicenseInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/AssignUserLicenseInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.entities;
 
 import org.jetbrains.annotations.NotNull;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/AuthorizationTokenInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/AuthorizationTokenInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.entities;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/AzureActiveDirectoryCommonInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/AzureActiveDirectoryCommonInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.entities;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/ChangeUserPasswordInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/ChangeUserPasswordInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.entities;
 
 import org.jetbrains.annotations.NotNull;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/CommonUserInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/CommonUserInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.entities;
 
 import org.jetbrains.annotations.NotNull;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/GetMemberGroupsInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/GetMemberGroupsInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.entities;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/GetUserInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/GetUserInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.entities;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/GetUserLicenseDetailsInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/GetUserLicenseDetailsInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.entities;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/RemoveUserLicenseInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/RemoveUserLicenseInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.entities;
 
 import org.jetbrains.annotations.NotNull;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/UpdateUserInputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/entities/UpdateUserInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.entities;
 
 import org.jetbrains.annotations.NotNull;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/AssignRemoveUserLicenseService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/AssignRemoveUserLicenseService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/AuthorizationTokenImpl.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/AuthorizationTokenImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.services;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/ChangeUserPasswordService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/ChangeUserPasswordService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/CreateUserService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/CreateUserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/DeleteUserService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/DeleteUserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import io.cloudslang.content.microsoftAD.entities.AzureActiveDirectoryCommonInputs;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/EnableDisableUserService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/EnableDisableUserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/GetMemberGroupsService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/GetMemberGroupsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/GetUserLicenseDetailsService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/GetUserLicenseDetailsService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import io.cloudslang.content.microsoftAD.entities.GetUserLicenseDetailsInputs;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/GetUserService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/GetUserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import io.cloudslang.content.microsoftAD.entities.GetUserInputs;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/HttpCommons.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/HttpCommons.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.microsoftAD.services;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/ResetUserPasswordService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/ResetUserPasswordService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/UpdateUserService.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/services/UpdateUserService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.microsoftAD.services;
 
 import com.google.gson.JsonObject;

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Constants.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.utils;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Descriptions.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Descriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.utils;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/HttpUtils.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/HttpUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.utils;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Inputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Inputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.utils;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/InputsValidation.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/InputsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.utils;
 

--- a/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Outputs.java
+++ b/cs-microsoft-ad/src/main/java/io/cloudslang/content/microsoftAD/utils/Outputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2021-2024 Open Text
+ * Copyright 2021-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.microsoftAD.utils;
 

--- a/cs-nutanix-prism/pom.xml
+++ b/cs-nutanix-prism/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    * Copyright 2022-2024 Open Text
+    * Copyright 2022-2025 Open Text
     * This program and the accompanying materials
     * are made available under the terms of the Apache License v2.0 which accompany this distribution.
     *
@@ -15,7 +15,6 @@
     * limitations under the License.
 
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -136,6 +135,17 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
         </dependency>
 
         <!--HTTP CLIENT-->
@@ -237,7 +247,7 @@
                         <include>pom.xml</include>
                     </includes>
                     <properties>
-                        <copyright.year>2022-2024</copyright.year>
+                        <copyright.year>2022-2025</copyright.year>
                     </properties>
                     <useDefaultMapping>false</useDefaultMapping>
                     <mapping>

--- a/cs-oracle-cloud/pom.xml
+++ b/cs-oracle-cloud/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    * Copyright 2020-2024 Open Text
+    * Copyright 2020-2025 Open Text
     * This program and the accompanying materials
     * are made available under the terms of the Apache License v2.0 which accompany this distribution.
     *
@@ -15,7 +15,6 @@
     * limitations under the License.
 
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -121,6 +120,17 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -281,7 +291,7 @@
                         <include>pom.xml</include>
                     </includes>
                     <properties>
-                        <copyright.year>2020-2024</copyright.year>
+                        <copyright.year>2020-2025</copyright.year>
                     </properties>
                     <useDefaultMapping>false</useDefaultMapping>
                     <mapping>

--- a/cs-sharepoint/pom.xml
+++ b/cs-sharepoint/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    * Copyright 2024 Open Text
+    * Copyright 2024-2025 Open Text
     * This program and the accompanying materials
     * are made available under the terms of the Apache License v2.0 which accompany this distribution.
     *
@@ -15,7 +15,6 @@
     * limitations under the License.
 
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -113,6 +112,12 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>2.9.0</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>com.microsoft.azure</groupId>
@@ -152,7 +157,7 @@
         <dependency>
             <groupId>net.minidev</groupId>
             <artifactId>json-smart</artifactId>
-            <version>2.5.0</version>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>io.cloudslang.content</groupId>
@@ -222,7 +227,7 @@
                         <include>pom.xml</include>
                     </includes>
                     <properties>
-                        <copyright.year>2024</copyright.year>
+                        <copyright.year>2024-2025</copyright.year>
                     </properties>
                     <useDefaultMapping>false</useDefaultMapping>
                     <mapping>

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/authorization/GetAuthorizationToken.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/authorization/GetAuthorizationToken.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.authorization;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetAllDrives.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetAllDrives.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.drives;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetDriveIdByName.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetDriveIdByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.drives;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetDriveNameById.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetDriveNameById.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.drives;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetRootDrive.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/drives/GetRootDrive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.drives;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/CopyItem.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/CopyItem.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2024-2025 Open Text
+ * This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.content.sharepoint.actions.entities;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GeEntityIdByName.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GeEntityIdByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GetEntitiesFromDrive.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GetEntitiesFromDrive.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GetEntityIdByName.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GetEntityIdByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GetEntityShareLink.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/GetEntityShareLink.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/MoveItem.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/MoveItem.java
@@ -1,3 +1,17 @@
+/*
+ * Copyright 2024-2025 Open Text
+ * This program and the accompanying materials
+ * are made available under the terms of the Apache License v2.0 which accompany this distribution.
+ *
+ * The Apache License is available at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package io.cloudslang.content.sharepoint.actions.entities;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/SearchForEntities.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/entities/SearchForEntities.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/files/DeleteFile.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/files/DeleteFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.files;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/files/DownloadFile.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/files/DownloadFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.files;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/files/UploadFile.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/files/UploadFile.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.files;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/folders/CreateFolder.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/folders/CreateFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.folders;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/folders/DeleteFolder.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/folders/DeleteFolder.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.folders;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/AddPermissions.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/AddPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.sharepoint.actions.permissions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/DeletePermission.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/DeletePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.sharepoint.actions.permissions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/ListPermissions.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/ListPermissions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.sharepoint.actions.permissions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/UpdatePermission.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/permissions/UpdatePermission.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package io.cloudslang.content.sharepoint.actions.permissions;
 
 import com.hp.oo.sdk.content.annotations.Action;

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetAllSites.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetAllSites.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.sites;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetRootSite.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetRootSite.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.sites;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetSiteDetails.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetSiteDetails.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.sites;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetSiteIdByName.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetSiteIdByName.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.sites;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetSiteNameById.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/actions/sites/GetSiteNameById.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.actions.sites;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/entities/GetAuthorizationTokenInputs.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/entities/GetAuthorizationTokenInputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/entities/HttpInput.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/entities/HttpInput.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.entities;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/services/GetAuthorizationTokenImpl.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/services/GetAuthorizationTokenImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.services;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/services/GetEntitiesFromDriveService.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/services/GetEntitiesFromDriveService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.services;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/services/SharepointService.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/services/SharepointService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.services;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Constants.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.utils;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Descriptions.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Descriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.utils;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Inputs.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Inputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.utils;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/InputsValidation.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/InputsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.utils;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Outputs.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Outputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.utils;
 

--- a/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Utils.java
+++ b/cs-sharepoint/src/main/java/io/cloudslang/content/sharepoint/utils/Utils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Open Text
+ * Copyright 2024-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 package io.cloudslang.content.sharepoint.utils;
 

--- a/cs-tesseract/pom.xml
+++ b/cs-tesseract/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    * Copyright 2022-2024 Open Text
+    * Copyright 2022-2025 Open Text
     * This program and the accompanying materials
     * are made available under the terms of the Apache License v2.0 which accompany this distribution.
     *
@@ -15,7 +15,6 @@
     * limitations under the License.
 
 -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
@@ -137,6 +136,17 @@
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>
             <version>${jayway-jsonpath.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.5.2</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -236,7 +246,7 @@
                         <include>pom.xml</include>
                     </includes>
                     <properties>
-                        <copyright.year>2022-2024</copyright.year>
+                        <copyright.year>2022-2025</copyright.year>
                     </properties>
                     <useDefaultMapping>false</useDefaultMapping>
                     <mapping>

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/actions/ExtractTextFromImage.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/actions/ExtractTextFromImage.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.actions;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/actions/ExtractTextFromPDF.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/actions/ExtractTextFromPDF.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.actions;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/actions/utils/TesseractSetup.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/actions/utils/TesseractSetup.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.actions.utils;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/services/ConfigService.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/services/ConfigService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.services;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/services/OcrService.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/services/OcrService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.services;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/services/PdfService.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/services/PdfService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.services;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Constants.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Constants.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.utils;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Descriptions.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Descriptions.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.utils;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Inputs.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Inputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.utils;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/InputsValidation.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/InputsValidation.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.utils;

--- a/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Outputs.java
+++ b/cs-tesseract/src/main/java/io/cloudslang/content/tesseract/utils/Outputs.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2022-2024 Open Text
+ * Copyright 2022-2025 Open Text
  * This program and the accompanying materials
  * are made available under the terms of the Apache License v2.0 which accompany this distribution.
  *
@@ -12,6 +12,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 
 
 package io.cloudslang.content.tesseract.utils;

--- a/pom.xml
+++ b/pom.xml
@@ -6,14 +6,6 @@
     <groupId>io.cloudslang.content</groupId>
     <artifactId>cs-actions</artifactId>
     <version>0.0.1-SNAPSHOT</version>
-    <dependencies>
-        <dependency>
-            <groupId>net.minidev</groupId>
-            <artifactId>json-smart</artifactId>
-            <version>2.2.1</version>
-            <scope>compile</scope>
-        </dependency>
-    </dependencies>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>


### PR DESCRIPTION
updated json-smart and copyright for cs-microsoft-ad, cs-nutanix-prism, cs-oracle-cloud, cs-sharepoint, cs-tesseract